### PR TITLE
feat: rename cc-tts to cc-voice for e2e voice scope

### DIFF
--- a/.cc-voice.example.toml
+++ b/.cc-voice.example.toml
@@ -1,5 +1,5 @@
-# CC-TTS configuration
-# Copy to .cc-tts.toml and adjust as needed.
+# CC-Voice configuration
+# Copy to .cc-voice.toml and adjust as needed.
 # Environment overrides: CC_TTS_ENGINE, CC_TTS_VOICE, CC_TTS_SPEED,
 # CC_TTS_AUTO_READ, CC_TTS_MAX_CHARS, CC_TTS_PLAYER
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,18 @@
 {
-  "name": "cc-tts",
+  "name": "cc-voice",
   "owner": {
     "name": "qte77"
   },
   "metadata": {
-    "description": "Text-to-speech output plugin for Claude Code with live PTY proxy and batch Stop hook",
-    "version": "0.1.0"
+    "description": "End-to-end voice plugin for Claude Code — TTS output and STT input (planned)",
+    "version": "0.2.0"
   },
   "plugins": [
     {
-      "name": "cc-tts",
+      "name": "cc-voice",
       "source": "./",
-      "description": "Live TTS via PTY proxy, batch TTS via Stop hook, /speak skill",
-      "version": "0.1.0"
+      "description": "TTS via PTY proxy and Stop hook (/speak), STT via Moonshine (/listen, planned)",
+      "version": "0.2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "cc-tts",
-  "version": "0.1.0",
-  "description": "Text-to-speech output for Claude Code. Adds /speak command and optional auto-read mode.",
+  "name": "cc-voice",
+  "version": "0.2.0",
+  "description": "End-to-end voice for Claude Code. TTS output via /speak, STT input via /listen (planned).",
   "author": {
     "name": "qte77"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,7 +71,7 @@
     "commit-helper@qte77-claude-code-utils": true,
     "codebase-tools@qte77-claude-code-utils": true,
     "cc-meta@qte77-claude-code-utils": true,
-    "cc-tts@cc-tts": true
+    "cc-voice@cc-voice": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-utils": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-04
+
+### Changed
+
+- Renamed from cc-tts to cc-voice (end-to-end voice scope)
+- Config file: `.cc-voice.toml` (reads legacy `.cc-tts.toml` as fallback)
+- Plugin name: `cc-voice` in plugin.json and marketplace.json
+
 ## [0.1.0] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# cc-tts (prototype)
+# cc-voice (prototype)
 
-> **Status: Prototype** — proof-of-concept for live TTS from Claude Code via PTY proxy. Not production-ready.
+> **Status: Prototype** — end-to-end voice for Claude Code. TTS output via PTY proxy, STT input planned. Not production-ready.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.1.0-58f4c2.svg)
+![Version](https://img.shields.io/badge/version-0.2.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype/badge)](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype)
 [![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)
 [![Link Checker](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml)
 
-Text-to-speech output plugin for Claude Code. Speaks Claude's responses aloud using local/OSS TTS engines.
+End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, STT input via Moonshine planned.
 
 ## Features
 
@@ -49,7 +49,7 @@ cc-tts "Hello from Claude Code"
 
 ## Configuration
 
-Create `.cc-tts.toml` in project root:
+Create `.cc-voice.toml` in project root (also reads legacy `.cc-tts.toml`):
 
 ```toml
 engine = "auto"              # "espeak" | "piper" | "kokoro" | "auto"
@@ -89,7 +89,7 @@ VERBOSE=1 make test # full pytest output
 Install as Claude Code plugin for `/speak` skill and Stop hook auto-read:
 
 ```bash
-claude plugin install cc-tts@local
+claude plugin install cc-voice@local
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "cc-tts"
-version = "0.1.0"
-description = "Text-to-speech output plugin for Claude Code"
+name = "cc-voice"
+version = "0.2.0"
+description = "End-to-end voice plugin for Claude Code — TTS output and STT input"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [{ name = "qte77" }]

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -26,7 +26,7 @@ python -m cc_tts.speak $ARGUMENTS
 
 ## Configuration
 
-Edit `.cc-tts.toml` in project root:
+Edit `.cc-voice.toml` in project root:
 
 ```toml
 engine = "auto"        # "piper" | "espeak" | "auto"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
-"""CC-TTS: Text-to-speech output plugin for Claude Code."""
+"""CC-Voice: End-to-end voice plugin for Claude Code."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/cc_tts/config.py
+++ b/src/cc_tts/config.py
@@ -7,7 +7,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-CONFIG_FILENAME = ".cc-tts.toml"
+CONFIG_FILENAMES = [".cc-voice.toml", ".cc-tts.toml"]
 
 
 @dataclass
@@ -23,12 +23,13 @@ class TTSConfig:
 
 
 def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-tts.toml."""
+    """Walk up from cwd to find .cc-voice.toml (or legacy .cc-tts.toml)."""
     current = Path.cwd()
     for directory in [current, *current.parents]:
-        candidate = directory / CONFIG_FILENAME
-        if candidate.is_file():
-            return candidate
+        for filename in CONFIG_FILENAMES:
+            candidate = directory / filename
+            if candidate.is_file():
+                return candidate
     return None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -136,8 +136,8 @@ wheels = [
 ]
 
 [[package]]
-name = "cc-tts"
-version = "0.1.0"
+name = "cc-voice"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Rename plugin from `cc-tts` to `cc-voice` for end-to-end voice (TTS + planned STT)
- Version bump 0.1.0 → 0.2.0
- Config file: `.cc-voice.toml` (reads legacy `.cc-tts.toml` as fallback)
- Updated: plugin.json, marketplace.json, pyproject.toml, README, CHANGELOG, SKILL.md, settings.json

## Test plan
- [x] `make validate` passes (66 tests, lint, type check)
- [x] Legacy `.cc-tts.toml` still works as fallback
- [ ] CI passes (CodeQL, CodeFactor, link checker)

Generated with Claude <noreply@anthropic.com>