### PR TITLE
fix: remove broken cc-voice plugin entry

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,8 +70,7 @@
     "python-dev@qte77-claude-code-utils": true,
     "commit-helper@qte77-claude-code-utils": true,
     "codebase-tools@qte77-claude-code-utils": true,
-    "cc-meta@qte77-claude-code-utils": true,
-    "cc-voice@cc-voice": true
+    "cc-meta@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-utils": {


### PR DESCRIPTION
## Summary
- Remove `cc-voice@cc-voice` from `enabledPlugins` (not discoverable after rename, see #7)
- Prevents stop hook errors on every response

## Test plan
- [x] `/doctor` shows no plugin errors
- [x] `/reload-plugins` loads cleanly (7 plugins)

Generated with Claude <noreply@anthropic.com>