### PR TITLE
fix(config): add MD041 front_matter_title to markdownlint

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD013": false,
+  "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" },
   "MD060": false
 }


### PR DESCRIPTION
## Summary

- Add `MD041.front_matter_title` to `.markdownlint.json` to recognize `title:` in YAML frontmatter as first heading
- Prevents false MD041 (first-line-heading) errors on files with frontmatter

Aligns with [ai-agents-research `.markdownlint.json`](https://github.com/qte77/ai-agents-research/blob/main/.markdownlint.json) and docs-governance recommended config.

## Test plan

- [ ] `markdownlint .` passes on repo markdown files with frontmatter

Generated with Claude <noreply@anthropic.com>