### PR TITLE
feat(stt): implement /listen pipeline with TDD

### DIFF
--- a/skills/listen/SKILL.md
+++ b/skills/listen/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # /listen
 
-Transcribe speech using local speech-to-text (planned).
+Transcribe speech using local speech-to-text.
 
 ## Usage
 
@@ -41,4 +41,4 @@ Environment overrides: `CC_STT_ENGINE`, `CC_STT_LANGUAGE`, `CC_STT_WAKE_WORD`, `
 
 ## Status
 
-Prototype — config, engine protocol, mic capture, utterance buffer, and PTY injection are implemented. Live listen pipeline integration is planned.
+Prototype — config, engine protocol, mic capture, utterance buffer, PTY injection, and live listen pipeline are implemented.

--- a/src/cc_stt/__main__.py
+++ b/src/cc_stt/__main__.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 
 def main() -> None:
-    """Route to subcommand: listen (default) or hook."""
+    """Route to subcommand: listen (default), hook, or file transcription."""
     if len(sys.argv) > 1 and sys.argv[1] == "hook":
         from cc_stt.hook_handler import should_auto_listen
 
@@ -14,8 +15,18 @@ def main() -> None:
             print("auto-listen: enabled", file=sys.stderr)
         sys.exit(0)
 
-    print("cc-stt: listen mode not yet implemented", file=sys.stderr)
-    sys.exit(1)
+    if len(sys.argv) > 1:
+        candidate = Path(sys.argv[1])
+        if candidate.is_file():
+            from cc_stt.listen import transcribe_file
+
+            text = transcribe_file(str(candidate))
+            print(text)
+            return
+
+    from cc_stt.listen import listen_live
+
+    listen_live()
 
 
 if __name__ == "__main__":

--- a/src/cc_stt/listen.py
+++ b/src/cc_stt/listen.py
@@ -7,7 +7,7 @@ import threading
 import wave
 from pathlib import Path
 
-from cc_stt.config import load_stt_config
+from cc_stt.config import STTConfig, load_stt_config
 from cc_stt.engine import resolve_stt_engine
 from cc_stt.mic import MicCapture
 from cc_stt.pty_input import inject_text
@@ -24,7 +24,7 @@ def _write_wav(pcm_bytes: bytes, path: str, *, sample_rate: int = 16000) -> None
 
 
 def listen_live(
-    config: object = None,
+    config: STTConfig | None = None,
     *,
     pty_fd: int | None = None,
     stop_event: threading.Event | None = None,
@@ -60,7 +60,7 @@ def listen_live(
         buffer.flush()
 
 
-def transcribe_file(path: str, config: object = None) -> str:
+def transcribe_file(path: str, config: STTConfig | None = None) -> str:
     """File -> engine -> text."""
     if not Path(path).is_file():
         msg = f"Audio file not found: {path}"

--- a/src/cc_stt/listen.py
+++ b/src/cc_stt/listen.py
@@ -1,0 +1,71 @@
+"""Live listen pipeline: mic -> buffer -> engine -> PTY injection."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import wave
+from pathlib import Path
+
+from cc_stt.config import load_stt_config
+from cc_stt.engine import resolve_stt_engine
+from cc_stt.mic import MicCapture
+from cc_stt.pty_input import inject_text
+from cc_stt.utterance_buffer import UtteranceBuffer
+
+
+def _write_wav(pcm_bytes: bytes, path: str, *, sample_rate: int = 16000) -> None:
+    """Write raw 16-bit PCM bytes to a WAV file."""
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_bytes)
+
+
+def listen_live(
+    config: object = None,
+    *,
+    pty_fd: int | None = None,
+    stop_event: threading.Event | None = None,
+) -> None:
+    """Mic -> buffer -> engine -> PTY injection.
+
+    Blocks until stop_event is set.
+    """
+    stt_config = load_stt_config() if config is None else config
+    engine = resolve_stt_engine(stt_config.engine)
+
+    def on_utterance(pcm_bytes: bytes) -> None:
+        """Transcribe utterance and inject text to PTY."""
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
+            _write_wav(pcm_bytes, tmp.name, sample_rate=16000)
+            text = engine.transcribe(tmp.name)
+        if text and pty_fd is not None:
+            inject_text(pty_fd, text)
+
+    buffer = UtteranceBuffer(on_utterance)
+
+    mic = MicCapture(
+        device=stt_config.mic_device,
+        on_audio=buffer.feed,
+    )
+    mic.start()
+
+    try:
+        if stop_event is not None:
+            stop_event.wait()
+    finally:
+        mic.stop()
+        buffer.flush()
+
+
+def transcribe_file(path: str, config: object = None) -> str:
+    """File -> engine -> text."""
+    if not Path(path).is_file():
+        msg = f"Audio file not found: {path}"
+        raise FileNotFoundError(msg)
+
+    stt_config = load_stt_config() if config is None else config
+    engine = resolve_stt_engine(stt_config.engine)
+    return engine.transcribe(path)

--- a/tests/test_stt_listen.py
+++ b/tests/test_stt_listen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_stt_listen.py
+++ b/tests/test_stt_listen.py
@@ -1,0 +1,217 @@
+"""Tests for cc_stt.listen — TDD RED phase."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from cc_stt.listen import listen_live, transcribe_file
+
+
+class TestListenLive:
+    @patch("cc_stt.listen.inject_text")
+    @patch("cc_stt.listen.UtteranceBuffer")
+    @patch("cc_stt.listen.MicCapture")
+    @patch("cc_stt.listen.resolve_stt_engine")
+    @patch("cc_stt.listen.load_stt_config")
+    def test_listen_live_starts_mic_and_resolves_engine(
+        self,
+        mock_config: MagicMock,
+        mock_resolve: MagicMock,
+        mock_mic_cls: MagicMock,
+        mock_buffer_cls: MagicMock,
+        mock_inject: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+        mock_engine = MagicMock(spec=True)
+        mock_resolve.return_value = mock_engine
+
+        mock_mic = MagicMock()
+        mock_mic_cls.return_value = mock_mic
+
+        stop = threading.Event()
+        stop.set()  # Stop immediately
+
+        listen_live(stop_event=stop)
+
+        mock_resolve.assert_called_once()
+        mock_mic_cls.assert_called_once()
+        mock_mic.start.assert_called_once()
+
+    @patch("cc_stt.listen.inject_text")
+    @patch("cc_stt.listen.UtteranceBuffer")
+    @patch("cc_stt.listen.MicCapture")
+    @patch("cc_stt.listen.resolve_stt_engine")
+    @patch("cc_stt.listen.load_stt_config")
+    def test_listen_live_stop_event_stops_mic(
+        self,
+        mock_config: MagicMock,
+        mock_resolve: MagicMock,
+        mock_mic_cls: MagicMock,
+        mock_buffer_cls: MagicMock,
+        mock_inject: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+        mock_resolve.return_value = MagicMock()
+
+        mock_mic = MagicMock()
+        mock_mic_cls.return_value = mock_mic
+
+        stop = threading.Event()
+        stop.set()
+
+        listen_live(stop_event=stop)
+
+        mock_mic.stop.assert_called_once()
+
+    @patch("cc_stt.listen.inject_text")
+    @patch("cc_stt.listen.UtteranceBuffer")
+    @patch("cc_stt.listen.MicCapture")
+    @patch("cc_stt.listen.resolve_stt_engine")
+    @patch("cc_stt.listen.load_stt_config")
+    def test_listen_live_injects_transcript_to_pty(
+        self,
+        mock_config: MagicMock,
+        mock_resolve: MagicMock,
+        mock_mic_cls: MagicMock,
+        mock_buffer_cls: MagicMock,
+        mock_inject: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+        mock_engine = MagicMock()
+        mock_engine.transcribe.return_value = "hello world"
+        mock_resolve.return_value = mock_engine
+
+        mock_mic = MagicMock()
+        mock_mic_cls.return_value = mock_mic
+
+        # Capture the on_utterance callback from UtteranceBuffer
+        captured_on_utterance = None
+
+        def capture_buffer(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal captured_on_utterance
+            captured_on_utterance = args[0] if args else kwargs.get("on_utterance")
+            return MagicMock()
+
+        mock_buffer_cls.side_effect = capture_buffer
+
+        stop = threading.Event()
+        stop.set()
+
+        listen_live(pty_fd=42, stop_event=stop)
+
+        # Simulate an utterance arriving
+        assert captured_on_utterance is not None
+        captured_on_utterance(b"\x00" * 100)
+
+        mock_engine.transcribe.assert_called_once()
+        mock_inject.assert_called_once_with(42, "hello world")
+
+    @patch("cc_stt.listen.MicCapture")
+    @patch("cc_stt.listen.resolve_stt_engine", side_effect=RuntimeError("No STT engine found"))
+    @patch("cc_stt.listen.load_stt_config")
+    def test_listen_live_handles_no_engine(
+        self,
+        mock_config: MagicMock,
+        mock_resolve: MagicMock,
+        mock_mic_cls: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+
+        with pytest.raises(RuntimeError, match="No STT engine found"):
+            listen_live()
+
+    @patch("cc_stt.listen.resolve_stt_engine")
+    @patch("cc_stt.listen.MicCapture", side_effect=RuntimeError("no input device"))
+    @patch("cc_stt.listen.load_stt_config")
+    def test_listen_live_handles_no_mic(
+        self,
+        mock_config: MagicMock,
+        mock_mic_cls: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+        mock_resolve.return_value = MagicMock()
+
+        with pytest.raises(RuntimeError, match="no input device"):
+            listen_live()
+
+
+class TestTranscribeFile:
+    @patch("cc_stt.listen.resolve_stt_engine")
+    @patch("cc_stt.listen.load_stt_config")
+    def test_transcribe_file_returns_text(
+        self,
+        mock_config: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+        mock_engine = MagicMock()
+        mock_engine.transcribe.return_value = "transcribed text"
+        mock_resolve.return_value = mock_engine
+
+        audio_file = tmp_path / "test.wav"
+        audio_file.write_bytes(b"\x00" * 100)
+
+        result = transcribe_file(str(audio_file))
+
+        assert result == "transcribed text"
+        mock_engine.transcribe.assert_called_once_with(str(audio_file))
+
+    @patch("cc_stt.listen.load_stt_config")
+    def test_transcribe_file_nonexistent_raises(
+        self,
+        mock_config: MagicMock,
+    ) -> None:
+        from cc_stt.config import STTConfig
+
+        mock_config.return_value = STTConfig()
+
+        with pytest.raises(FileNotFoundError):
+            transcribe_file("/nonexistent/audio.wav")
+
+
+class TestMainDispatch:
+    @patch("cc_stt.listen.listen_live")
+    def test_main_dispatches_listen(
+        self,
+        mock_listen: MagicMock,
+    ) -> None:
+        from cc_stt.__main__ import main
+
+        with patch("sys.argv", ["cc-stt"]):
+            main()
+
+        mock_listen.assert_called_once()
+
+    @patch("cc_stt.listen.transcribe_file", return_value="hello")
+    def test_main_dispatches_file_transcription(
+        self,
+        mock_transcribe: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from cc_stt.__main__ import main
+
+        audio_file = tmp_path / "test.wav"
+        audio_file.write_bytes(b"\x00" * 100)
+
+        with patch("sys.argv", ["cc-stt", str(audio_file)]):
+            main()
+
+        mock_transcribe.assert_called_once_with(str(audio_file))


### PR DESCRIPTION
## Summary

- Implement `/listen` command: live mic capture and file transcription
- `listen_live()`: mic → utterance buffer → engine → PTY injection
- `transcribe_file()`: file → engine → text output
- 9 new tests (122 total), strict TDD Red-Green-Refactor

## Files

| File | Change |
|------|--------|
| `src/cc_stt/listen.py` | New orchestrator module |
| `src/cc_stt/__main__.py` | Updated dispatch (listen/file/hook) |
| `tests/test_stt_listen.py` | 9 tests: live, transcribe, dispatch |
| `skills/listen/SKILL.md` | Updated status |

## Test plan

- [x] 122/122 tests pass (`uv run python -m pytest -v`)
- [x] TDD Red-Green-Refactor followed
- [ ] `/listen recording.wav` transcribes file
- [ ] `/listen` starts live capture (requires mic hardware)

Refs qte77/claude-code-utils-plugin#75

Generated with Claude <noreply@anthropic.com>