### PR TITLE
chore: bump v0.4.0 + CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "End-to-end voice plugin for Claude Code — TTS output and STT input",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "cc-voice",
       "source": "./",
       "description": "TTS via PTY proxy and Stop hook (/speak), STT via Moonshine/Vosk (/listen)",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-voice",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "End-to-end voice for Claude Code. TTS output via /speak, STT input via /listen.",
   "author": {
     "name": "qte77"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,31 @@
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-04-06
+## [0.4.0] - 2026-04-11
 
 ### Added
-- feat(stt): live `/listen` pipeline — mic capture → VAD buffering → Moonshine/Vosk transcription → PTY injection
-- feat(stt): file transcription mode via `transcribe_file()` 
-- feat(stt): `__main__.py` dispatcher routing to listen/transcribe/hook modes
-- test: 9 listen pipeline tests (TestListenLive, TestTranscribeFile, TestMainDispatch)
-- test: 19 plugin config validation tests (plugin.json schema, marketplace source resolution)
+- feat(stt): live `/listen` pipeline — mic capture → VAD buffering → Moonshine/Vosk transcription → PTY injection (#14)
+- feat(stt): file transcription mode via `transcribe_file()` (#14)
+- feat(stt): `__main__.py` dispatcher routing to listen/transcribe/hook modes (#14)
+- docs(vlm): ADR-0001 screen-sharing architecture for `/see` — three tiers (CC-native vision, local VLM, hybrid) (#18)
+- docs(vlm): `/see` skill stub (status: research) (#18)
+- build(make): `setup_all` happy-path target installing dev + TTS engines + STT deps (#19)
+- build(make): `setup_stt` target using existing `[stt]` extras group (#19)
+- build(make): `clean` target removing `.venv` + caches (#19)
+- test: 9 listen pipeline tests — TestListenLive, TestTranscribeFile, TestMainDispatch (#14)
+- test: 19 plugin config validation tests — plugin.json schema, marketplace source resolution (#13)
+
+### Changed
+- fix(types): adopt pyright strict + suppress-unknowns config — resolves untyped-library leakage from sounddevice / pydantic-settings; ported from sibling project Agents-eval (#19)
+- fix(types): narrow `listen.py` config parameter to `STTConfig | None` instead of `object` (#14)
+- chore(build): Makefile uses `uv sync` only — dropped `uv pip install` rule violations in `setup` and `setup_dev` (#19)
+- chore(build): rename `setup_tts` → `setup_espeak` for accuracy (it installs espeak-ng + mpv, not TTS generically) (#19)
+- chore(build): `test_coverage` now reports both `cc_tts` and `cc_stt` — previously silently dropped `cc_stt` (#19)
+- chore(build): `wrap` help text now warns about bwrap sandbox deadlock per AGENT_LEARNINGS.md (#19)
+- chore(gitignore): exclude `.coverage` artifact (#25)
+- style: ruff format drift cleanup across 5 files (src/cc_stt/mic.py, test_plugin_config.py, test_stt_config.py, test_stt_engine.py, test_stt_mic.py) (#25)
+- build(deps-dev): bump edge-tts ≥6.1.0 → ≥7.2.8 (#20)
+- build(deps-dev): bump bump-my-version ≥0.29.0 → ≥1.3.0 (#21)
 
 ### Fixed
 - fix: plugin discovery — changed marketplace source from relative path to github source type (#7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-06
+
+### Added
+- feat(stt): live `/listen` pipeline — mic capture → VAD buffering → Moonshine/Vosk transcription → PTY injection
+- feat(stt): file transcription mode via `transcribe_file()` 
+- feat(stt): `__main__.py` dispatcher routing to listen/transcribe/hook modes
+- test: 9 listen pipeline tests (TestListenLive, TestTranscribeFile, TestMainDispatch)
+- test: 19 plugin config validation tests (plugin.json schema, marketplace source resolution)
+
+### Fixed
+- fix: plugin discovery — changed marketplace source from relative path to github source type (#7)
+- fix: suppress CodeFactor B607/B108 warnings (#11)
+
 ## [0.3.0] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Status: Prototype** — end-to-end voice for Claude Code. TTS output via PTY proxy, STT input module scaffolded (config, engine, mic, VAD, PTY injection). Not production-ready.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.3.0-58f4c2.svg)
+![Version](https://img.shields.io/badge/version-0.4.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype/badge)](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype)
 [![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-voice"
-version = "0.3.0"
+version = "0.4.0"
 description = "End-to-end voice plugin for Claude Code — TTS output and STT input"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -82,7 +82,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.4.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
 """cc-stt: Speech-to-text module for cc-voice plugin."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
 """CC-Voice: End-to-end voice plugin for Claude Code."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "cc-voice"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump version 0.3.0 → 0.4.0 across all version files
- Update CHANGELOG with entries for #7, #13, #14

## Test plan
- [ ] `grep '"version": "0.4.0"' .claude-plugin/plugin.json` confirms version
- [ ] `uv run python -m pytest -v` — all tests pass
- [ ] CHANGELOG entries reference correct issue numbers

> **Stacked PR**: PR #14 (`feat/stt-listen`) must merge before this one.

Closes #15

Generated with Claude <noreply@anthropic.com>