### PR TITLE
chore: repo hygiene — gitignore .coverage + ruff format drift cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ __pycache__/
 dist/
 .pytest_cache/
 .ruff_cache/
+.coverage
 # Claude Code local overrides
 .claude/settings.local.json

--- a/src/cc_stt/mic.py
+++ b/src/cc_stt/mic.py
@@ -69,9 +69,7 @@ class MicCapture:
     def is_active(self) -> bool:
         return self._stream is not None
 
-    def _callback(
-        self, indata: Any, frames: int, time: Any, status: Any
-    ) -> None:
+    def _callback(self, indata: Any, frames: int, time: Any, status: Any) -> None:
         """Sounddevice callback — converts numpy array to bytes and delivers."""
         if self._on_audio is not None:
             self._on_audio(indata.tobytes())
@@ -80,9 +78,7 @@ class MicCapture:
         """Start capturing audio from microphone."""
         if self._stream is not None:
             return
-        self._stream = _open_stream(
-            self.device, self.sample_rate, self.channels, self._callback
-        )
+        self._stream = _open_stream(self.device, self.sample_rate, self.channels, self._callback)
 
     def stop(self) -> None:
         """Stop capturing audio."""

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -90,23 +90,17 @@ class TestMarketplaceJsonSchema:
 
 
 class TestMarketplacePluginEntries:
-    def test_each_plugin_has_name_and_source(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_each_plugin_has_name_and_source(self, marketplace_data: dict[str, object]) -> None:
         for entry in marketplace_data["plugins"]:  # type: ignore[union-attr]
             assert "name" in entry, f"plugin entry missing 'name': {entry}"
             assert "source" in entry, f"plugin entry missing 'source': {entry}"
 
-    def test_plugin_names_kebab_case(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_plugin_names_kebab_case(self, marketplace_data: dict[str, object]) -> None:
         for entry in marketplace_data["plugins"]:  # type: ignore[union-attr]
             name = entry["name"]
             assert KEBAB_CASE_RE.match(name), f"plugin name '{name}' must be kebab-case"
 
-    def test_no_duplicate_plugin_names(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_no_duplicate_plugin_names(self, marketplace_data: dict[str, object]) -> None:
         names = [e["name"] for e in marketplace_data["plugins"]]  # type: ignore[union-attr]
         assert len(names) == len(set(names)), f"duplicate plugin names: {names}"
 
@@ -117,9 +111,7 @@ class TestMarketplacePluginEntries:
 class TestPluginSourceResolution:
     """Verify plugin sources resolve to valid plugin directories."""
 
-    def test_relative_source_resolves(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_relative_source_resolves(self, marketplace_data: dict[str, object]) -> None:
         for entry in marketplace_data["plugins"]:  # type: ignore[union-attr]
             source = entry["source"]
             if isinstance(source, str) and source.startswith("./"):
@@ -128,9 +120,7 @@ class TestPluginSourceResolution:
                     f"relative source '{source}' does not resolve to a directory"
                 )
 
-    def test_relative_source_has_plugin_json(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_relative_source_has_plugin_json(self, marketplace_data: dict[str, object]) -> None:
         for entry in marketplace_data["plugins"]:  # type: ignore[union-attr]
             source = entry["source"]
             if isinstance(source, str) and source.startswith("./"):
@@ -139,9 +129,7 @@ class TestPluginSourceResolution:
                     f"relative source '{source}' missing .claude-plugin/plugin.json"
                 )
 
-    def test_relative_source_not_git_submodule(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_relative_source_not_git_submodule(self, marketplace_data: dict[str, object]) -> None:
         """Git submodules are NOT initialized during CC marketplace clone.
 
         If a plugin source is a relative path to a git submodule, the
@@ -158,16 +146,13 @@ class TestPluginSourceResolution:
                     f"Use {{'source': 'github', 'repo': '...'}} instead."
                 )
 
-    def test_self_referential_source_resolves(
-        self, marketplace_data: dict[str, object]
-    ) -> None:
+    def test_self_referential_source_resolves(self, marketplace_data: dict[str, object]) -> None:
         """Source './' means the repo root IS the plugin."""
         for entry in marketplace_data["plugins"]:  # type: ignore[union-attr]
             source = entry["source"]
             if source == "./":
                 assert PLUGIN_JSON.is_file(), (
-                    "self-referential source './' requires .claude-plugin/plugin.json "
-                    "at repo root"
+                    "self-referential source './' requires .claude-plugin/plugin.json at repo root"
                 )
 
 

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -35,9 +35,7 @@ class TestLoadSTTConfigFromToml:
         assert config.engine == "moonshine"
         assert config.language == "de"
 
-    def test_returns_defaults_when_no_toml(
-        self, tmp_path: Path, monkeypatch: object
-    ) -> None:
+    def test_returns_defaults_when_no_toml(self, tmp_path: Path, monkeypatch: object) -> None:
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_stt_config()
         assert config.engine == "auto"
@@ -52,9 +50,7 @@ class TestLoadSTTConfigFromToml:
         config = load_stt_config()
         assert config.engine == "auto"
 
-    def test_falls_back_to_cc_tts_toml(
-        self, tmp_path: Path, monkeypatch: object
-    ) -> None:
+    def test_falls_back_to_cc_tts_toml(self, tmp_path: Path, monkeypatch: object) -> None:
         toml_content = b'[stt]\nengine = "vosk"\n'
         config_file = tmp_path / ".cc-tts.toml"
         config_file.write_bytes(toml_content)
@@ -64,9 +60,7 @@ class TestLoadSTTConfigFromToml:
 
 
 class TestSTTEnvOverrides:
-    def test_env_overrides_toml(
-        self, tmp_path: Path, monkeypatch: object
-    ) -> None:
+    def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: object) -> None:
         toml_content = b'[stt]\nengine = "moonshine"\n'
         config_file = tmp_path / ".cc-voice.toml"
         config_file.write_bytes(toml_content)
@@ -75,17 +69,13 @@ class TestSTTEnvOverrides:
         config = load_stt_config()
         assert config.engine == "vosk"
 
-    def test_bool_env_parsing(
-        self, tmp_path: Path, monkeypatch: object
-    ) -> None:
+    def test_bool_env_parsing(self, tmp_path: Path, monkeypatch: object) -> None:
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         monkeypatch.setenv("CC_STT_AUTO_LISTEN", "true")  # type: ignore[union-attr]
         config = load_stt_config()
         assert config.auto_listen is True
 
-    def test_string_env_override(
-        self, tmp_path: Path, monkeypatch: object
-    ) -> None:
+    def test_string_env_override(self, tmp_path: Path, monkeypatch: object) -> None:
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         monkeypatch.setenv("CC_STT_MIC_DEVICE", "hw:1,0")  # type: ignore[union-attr]
         config = load_stt_config()

--- a/tests/test_stt_engine.py
+++ b/tests/test_stt_engine.py
@@ -110,9 +110,7 @@ class TestResolveSTTEngine:
 
     @patch(
         "shutil.which",
-        side_effect=lambda x: "/usr/bin/vosk-transcriber"
-        if x == "vosk-transcriber"
-        else None,
+        side_effect=lambda x: "/usr/bin/vosk-transcriber" if x == "vosk-transcriber" else None,
     )
     def test_auto_falls_back_to_vosk(self, mock_which: object) -> None:
         engine = resolve_stt_engine("auto")

--- a/tests/test_stt_mic.py
+++ b/tests/test_stt_mic.py
@@ -26,17 +26,13 @@ class TestMicCaptureInit:
 
     @patch("cc_stt.mic._check_sounddevice")
     @patch("cc_stt.mic._query_devices", side_effect=NoMicrophoneError("no input device"))
-    def test_raises_when_no_input_device(
-        self, mock_query: object, mock_check: object
-    ) -> None:
+    def test_raises_when_no_input_device(self, mock_query: object, mock_check: object) -> None:
         with pytest.raises(NoMicrophoneError, match="no input device"):
             MicCapture()
 
     @patch("cc_stt.mic._query_devices", return_value="default")
     @patch("cc_stt.mic._check_sounddevice")
-    def test_creates_with_default_device(
-        self, mock_check: object, mock_query: object
-    ) -> None:
+    def test_creates_with_default_device(self, mock_check: object, mock_query: object) -> None:
         mic = MicCapture()
         assert mic.device == "default"
         assert mic.sample_rate == 16000
@@ -45,9 +41,7 @@ class TestMicCaptureInit:
 class TestMicCaptureCallback:
     @patch("cc_stt.mic._query_devices", return_value="default")
     @patch("cc_stt.mic._check_sounddevice")
-    def test_on_audio_receives_frames(
-        self, mock_check: object, mock_query: object
-    ) -> None:
+    def test_on_audio_receives_frames(self, mock_check: object, mock_query: object) -> None:
         received: list[bytes] = []
         mic = MicCapture(on_audio=received.append)
 
@@ -60,9 +54,7 @@ class TestMicCaptureCallback:
 
     @patch("cc_stt.mic._query_devices", return_value="default")
     @patch("cc_stt.mic._check_sounddevice")
-    def test_default_callback_is_noop(
-        self, mock_check: object, mock_query: object
-    ) -> None:
+    def test_default_callback_is_noop(self, mock_check: object, mock_query: object) -> None:
         mic = MicCapture()
         import numpy as np
 
@@ -100,9 +92,7 @@ class TestMicCaptureStartStop:
 
     @patch("cc_stt.mic._query_devices", return_value="default")
     @patch("cc_stt.mic._check_sounddevice")
-    def test_stop_without_start_is_noop(
-        self, mock_check: object, mock_query: object
-    ) -> None:
+    def test_stop_without_start_is_noop(self, mock_check: object, mock_query: object) -> None:
         mic = MicCapture()
         mic.stop()  # Should not raise
         assert mic.is_active is False


### PR DESCRIPTION
## Summary

Two trivial repo hygiene fixes bundled as topical commits:

- **chore(gitignore)**: add `.coverage` to the existing Python section. Generated by `make test_coverage`, was previously showing in `git status` as untracked. Already removed by `make clean` (added in PR #19), so cleanup paths stay consistent.
- **style**: pure `ruff format` pass on the 5 files that had drifted from formatter output on main: `src/cc_stt/mic.py`, `tests/test_plugin_config.py`, `tests/test_stt_config.py`, `tests/test_stt_engine.py`, `tests/test_stt_mic.py`. No logic changes.

## Why a separate PR

These were intentionally excluded from PR #19 (build + typing cleanup) to keep the diff scoped. PR #19 fixes infrastructure rules (`uv pip` violation, missing coverage, type config); this PR fixes pre-existing format drift unrelated to those rules. Reviewers can scan each PR independently.

## Test plan

- [x] `make test` → 132/132 passing
- [x] `make lint_src` → 0 warnings (was 1 pre-existing for `mic.py`)
- [x] `make lint_tests` → 0 warnings (was 4 pre-existing across test files)
- [x] `git status` no longer shows `.coverage` after running `make test_coverage`
- [x] No logic changes — diff is whitespace and trailing commas only

## Merge order

Independent of PR #19. Either order works; conflicts are not expected since:
- This PR doesn't touch `Makefile` or `pyproject.toml` (PR #19's targets)
- PR #19 doesn't touch the 5 reformatted files

If PR #19 merges first, this PR rebases cleanly. If this PR merges first, PR #19 rebases cleanly.

## Related

- Part of cc-voice 0.4.x hardening
- Companion to PR #19

Generated with Claude <noreply@anthropic.com>