### PR TITLE
docs(roadmap): add v0.5.x roadmap tracking deferred and rejected work

### DIFF
--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -1,0 +1,118 @@
+# cc-voice v0.5.x roadmap
+
+Living document for tracked and deferred work on the 0.5.x development line.
+**Actionable items are filed as GitHub issues** with the `enhancement` label;
+this file captures the **deferred** items and **rejected** directions that
+don't belong in the issue tracker.
+
+## Source of truth
+
+- **Actionable work**: [GitHub issues](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+- **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- **Deferred ideas + rejected paths**: this file
+- **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-voice-plugin-prototype/memory/`
+
+## Recently shipped
+
+| Version | PRs | Highlights |
+|---|---|---|
+| **v0.4.0** (tagged 2026-04-11) | #14, #17, #18, #19, #20, #21, #22, #23, #24, #25 | `/listen` pipeline, ADR-0001 (VLM screen-sharing), build + typing cleanup, dep-bump sweep, repo hygiene |
+| **v0.5.0** (unreleased — tracked in #34) | #26, #28 | `/see` module (`cc_vlm` with `llama-cpp-python`), `setup_user` Makefile target |
+
+## Tracked in GitHub issues (actionable)
+
+Filed alongside this roadmap — see each issue for full scope + acceptance criteria:
+
+- **#29** — `feat(listen): token optimization — filler strip + local intent match + word cap`
+- **#30** — `feat(tts): Kokoro voice blending via embedding math`
+- **#31** — `feat(stt): Whisper engine via faster-whisper (enables domain fine-tunes)`
+- **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr (multilingual, CC-BY-4.0)`
+- **#33** — `docs(adr): update ADR-0001 — Qwen3-VL-2B, LFM2-VL-3B, Tier-2-first decision`
+- **#34** — `chore(release): tag v0.5.0`
+
+When one of these lands, link back to this file if scope expanded or contracted.
+
+## Deferred ideas — not currently filed as issues
+
+These were considered during the 0.4.0 hardening session and intentionally
+parked. They may become actionable later when usage patterns justify them.
+Listed here so anyone reading the repo sees what's on the radar without
+filing noise in the tracker.
+
+### Engines
+
+- **Orpheus-TTS engine via llama-cpp-python** — enables Unsloth fine-tune
+  path for domain-adapted TTS. Gate on actual user demand for fine-tuned
+  custom voices (not a pressing need today). ~100 LOC + an already-present
+  `llama-cpp-python` dep from `cc_vlm`.
+
+### Tooling / build
+
+- **complexipy cognitive complexity gate** (from the `so101-biolab-automation`
+  pattern) — dev dep + `make complexity` target, max 15 per function. Low
+  urgency; `listen.py` and `pty_proxy.py` aren't hitting the limit yet.
+- **`[tool.uv] exclude-newer = "YYYY-MM-DDT..."`** for reproducible dep
+  resolution. Trivial one-line config. Ship when something breaks.
+- **pytest `hardware` marker** (from `so101` pattern) — `addopts =
+  "--strict-markers -m 'not hardware'"`, one marker definition. Currently
+  we mock the mic; the marker becomes useful when we add real-hardware
+  integration tests.
+
+### Docs
+
+- **README + docs restructure** — slim README ≤60 lines, create
+  `docs/config.md` as the single source of truth for `.cc-voice.toml`,
+  add `docs/engines.md`, `docs/architecture.md`, `CONTRIBUTING.md`,
+  dedupe SKILL.md config sections. Large scope, good hygiene, not blocking
+  any feature work.
+- **ADR-0002 "full-duplex voice" future direction** — PersonaPlex / Moshi
+  architecture note. Historical record; cc-voice stays half-duplex with
+  pluggable engines by design. Write when someone asks about the
+  architectural frontier.
+- **6-line terseness prompt** in `.claude/rules/core-principles.md` — per
+  the jakguzik caveman benchmark (dev.to), a small prompt addition
+  captures most of caveman's token savings (13-21% real, not the viral
+  65-75% claim) without installing a plugin. Only worth doing if `rtk` +
+  existing `core-principles.md` aren't enough in practice.
+
+## Rejected directions — do NOT reconsider without new evidence
+
+These were researched and decided against during 0.4.x hardening. Preserved
+here to prevent re-research in future sessions.
+
+| Item | Why not |
+|---|---|
+| **inferrs** as VLM backend | Text-LLM only; no vision support anywhere in README/features. Verified via WebFetch. |
+| **Unsloth → Kokoro fine-tune → GGUF** | Architecturally impossible: Kokoro is StyleTTS2 (not transformers-compatible), not in Unsloth's supported model list, and has no official fine-tune script. The correct custom-voice path is **embedding blending** — tracked as #30. |
+| **DPT-2 Mini (Landing AI)** | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-voice's local-first positioning. |
+| **TurboQuant-GPU** (DevTechJr) | KV cache compression for text LLMs; NVIDIA-only; no VLM/audio support. Scope mismatch. |
+| **caveman as plugin** | Real savings are 13-21% per independent benchmark (not the viral 65-75% claim). Redundant with `core-principles.md` + `rtk` already in place. A 6-line prompt matches the full plugin's effect. |
+| **Claude Code router as cc-voice dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-voice's audio/vision pipeline is unaffected by backend routing. |
+| **PersonaPlex adoption** | Scope mismatch — replaces Claude Code's LLM entirely. cc-voice's value prop is "Claude Code does the thinking". Only useful as a future-direction note (deferred idea above). |
+| **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-voice doesn't need to re-document external tools. |
+| **`context-mode`** deep research | Unresearched, not urgent. Revisit only if `rtk`'s command-output compression proves insufficient. |
+
+## Process notes
+
+### Filing new enhancement issues
+
+Follow the pattern of #29-#33 — Summary, Context, Scope, Non-goals,
+Acceptance criteria. Keep each issue to ~40-80 lines. Use the `enhancement`
+label and `python` label if it touches Python code.
+
+### Moving deferred items to issues
+
+When a deferred item above becomes actionable (demand appears, a dependency
+ships, a pattern gets validated elsewhere), file it as an issue with a
+pointer back to this file in the body so the history is clear.
+
+### Session memory vs repo docs vs tracker
+
+- **Session memory** (`~/.claude/projects/.../memory/`): operational knowledge
+  that doesn't belong in code but needs to survive between sessions. Things
+  like "main ruleset requires signatures; use `--admin` for merges", "dependabot
+  chained conflict recovery pattern", "Kokoro is not fine-tunable".
+- **Repo docs** (this file, ADRs, SKILL.md): intent, design decisions,
+  user-facing how-tos. Version-controlled, collaborator-visible.
+- **GitHub tracker**: actionable work with clear acceptance criteria. Bugs
+  users file, features with a review audience.


### PR DESCRIPTION
## Summary

Adds `docs/roadmap/v0.5.x.md` as the version-controlled source of truth for deferred ideas and rejected directions — the category of items that shouldn't be filed as GitHub issues but still need to survive between development sessions.

## Why

Earlier in this session, #26 and #28 shipped the `/see` module and `setup_user` target. A pile of related work was considered but not actioned in either of those PRs — some of it is genuinely near-term (just filed as issues #29-#34), but a lot is "good idea, not yet justified" or "deliberately rejected — don't re-research this".

Filing all of it as issues would clutter the tracker. Leaving it only in my local plan file (`~/.claude/plans/cc-voice-0.4.0-hardening.md`) means it disappears if that machine is lost or someone else picks up the repo.

This file splits the difference:

- **Tracked** (issues) — actionable work filed now: #29 `/listen` token opts, #30 Kokoro blending, #31 Whisper engine, #32 Parakeet engine, #33 ADR-0001 amendment, #34 v0.5.0 release
- **Deferred ideas** (this file) — Orpheus-TTS engine, complexipy gate, `exclude-newer` uv config, pytest hardware marker, README/docs restructure, ADR-0002 full-duplex direction, terseness prompt
- **Rejected directions** (this file) — inferrs (text LLM only), Unsloth→Kokoro (architecture mismatch), DPT-2 Mini, TurboQuant-GPU, caveman plugin, CC router as dep, PersonaPlex adoption, etc.

## What's in the file

- Summary of recently shipped work (v0.4.0 merged, v0.5.0 pending #34)
- Pointers to the six tracked issues (#29-#34)
- Deferred-ideas section with enough context for each that they can be promoted to issues later without re-research
- Rejected-directions table with the \"why not\" for each (prevents re-researching the same rabbit holes)
- Process notes on when to use session memory vs repo docs vs GitHub tracker

## Test plan

- [x] `make lint_md` on the new file
- [x] All internal links valid (GitHub issue numbers, file paths)
- [ ] Manual review that the rejected reasons are accurate (they were decided this session)

## Related

- Closes the meta-gap from #12 (research issue closed separately with full gravestone)
- Pairs with #29-#34 — those are the \"now\" work; this file is the \"later + never\"
- Follows the \"commit files by topic\" preference established in earlier PRs (#25 hygiene, #26 /see, #28 setup_user) — file over issues for ideas and history

Generated with Claude <noreply@anthropic.com>