### PR TITLE
chore(release): bump v0.4.0 → v0.5.0 + CHANGELOG

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "End-to-end voice plugin for Claude Code — TTS output and STT input",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {
       "name": "cc-voice",
       "source": "./",
       "description": "TTS via PTY proxy and Stop hook (/speak), STT via Moonshine/Vosk (/listen)",
-      "version": "0.4.0"
+      "version": "0.5.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-voice",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "End-to-end voice for Claude Code. TTS output via /speak, STT input via /listen.",
   "author": {
     "name": "qte77"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-11
+
+### Added
+- feat(see): `cc_vlm` module with in-process `llama-cpp-python` backend — `/see` skill captures screen, runs a local VLM (Qwen2.5-VL default) with task-constrained prompt templates, returns a text description for Claude's prompt. ~120 tokens/call vs ~1,600 for raw vision (~13× reduction); 0 tokens on cache hits via BLAKE3 frame hash LRU. (#26)
+- feat(see): `--image-file PATH` flag — describe a pre-captured image instead of capturing the screen; enables headless testing and saved-screenshot use cases. (#26)
+- feat(see): five task-constrained prompt templates (terminal, editor, browser, gui, generic) capping VLM output length at the source. (#26)
+- feat(see): `LlamaCppVLMEngine` supporting six model families via `_HANDLER_MAP` (qwen2.5vl, llava15, llava16, moondream, minicpmv, nanollava). (#26)
+- build(make): `setup_user` target — end-user minimum install (package + best local TTS), no dev tools. `setup_all` clarified as "Developer happy path". (#28)
+- build(make): `setup_see` target — installs `[see]` extras (mss, Pillow, blake3) and prints hardware-specific `llama-cpp-python` install commands (CPU / CUDA / Metal / ROCm). (#26)
+- build(make): `plugin_validate`, `plugin_install_local`, `plugin_uninstall`, `plugin_list`, `run_cc` targets — full plugin-in-CC lifecycle for local dev. (#26)
+- build(make): `smoke_imports`, `smoke_cli`, `smoke` targets — fast sanity checks that don't need external deps. (#26)
+- build(make): `listen`, `see`, `see_file`, `see_save_only` direct-run targets (bypass CC for testing). (#26)
+- build(make): `clean_models`, `clean_see_artifacts`, `clean_all` targets — remove downloaded VLM models, `/tmp` JPEGs, and full local reset. (#26)
+- docs(roadmap): `docs/roadmap/v0.5.x.md` — living tracker for deferred ideas and rejected directions alongside filed issues. (#35)
+
+### Changed
+- fix(types): narrow `listen.py` config parameter to `STTConfig | None` (was `object`) — eliminates pyright strict errors without per-line suppressions. (#26)
+- fix(stt): add `argparse` to `cc_stt/__main__.py` — `python -m cc_stt --help` now works; previously jumped straight to `listen_live()` and errored. Backward compat preserved for `python -m cc_stt hook` and file transcription. (#26)
+- chore(build): `[project.optional-dependencies] all` now uses PEP 621 self-references (`cc-voice[piper]`, etc.) instead of duplicating every dep — fixed long-standing DRY violation. (#26)
+
 ## [0.4.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Status: Prototype** — end-to-end voice for Claude Code. TTS output via PTY proxy, STT input module scaffolded (config, engine, mic, VAD, PTY injection). Not production-ready.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.4.0-58f4c2.svg)
+![Version](https://img.shields.io/badge/version-0.5.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype/badge)](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype)
 [![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-voice"
-version = "0.4.0"
+version = "0.5.0"
 description = "End-to-end voice plugin for Claude Code — TTS output and STT input"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -92,7 +92,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "0.4.0"
+current_version = "0.5.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
 """cc-stt: Speech-to-text module for cc-voice plugin."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
 """CC-Voice: End-to-end voice plugin for Claude Code."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "cc-voice"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Bumps version 0.4.0 → 0.5.0 and fills in the CHANGELOG with the three PRs landed since v0.4.0:

- **#26** `/see` module — `cc_vlm` with llama-cpp-python in-process backend, Qwen2.5-VL default, 5 prompt templates, BLAKE3 frame hash LRU cache, `--image-file` flag, `--no-cache`, `--save-only`, `--monitor`, `cc_stt --help` argparse fix, 215 total tests
- **#28** `setup_user` Makefile target for end-user minimum install
- **#35** `docs/roadmap/v0.5.x.md` tracking deferred and rejected work

Closes #34.

## Test plan

- [x] `uv run bump-my-version bump --no-commit --no-tag minor` updated all 7 version files consistently
- [x] `grep '^version' pyproject.toml` → `0.5.0`
- [x] `grep '"version"' .claude-plugin/plugin.json` → `0.5.0`
- [x] `make validate` → 215/215 tests pass, 0 lint, 0 type errors
- [x] CHANGELOG `[0.5.0]` section manually curated to reflect actual PRs

## Release sequence after merge

1. `gh pr merge <this PR> --squash --admin`
2. `git checkout main && git pull --ff-only`
3. `git tag -a v0.5.0 <squash sha> -m "Release v0.5.0"` (retroactive tag — bump-my-version did NOT create one because we ran with `--no-tag` to avoid orphaning it during squash-merge)
4. `git push origin v0.5.0`
5. `gh release create v0.5.0 --title "v0.5.0 — /see module" --notes-from-tag`

Same retag pattern used successfully for v0.4.0 (see session memory `reference_bump_and_tag_workflow.md`).

## Related

- #26 `/see` module — primary feature
- #28 `setup_user` target — secondary addition
- #35 roadmap file — context
- Closes #34 (release tracking issue)
- #33 ADR-0001 amendment — separate follow-up docs PR, not bundled here

Generated with Claude <noreply@anthropic.com>