### PR TITLE
fix(docs): add missing kokoro to /speak SKILL.md engine list

### DIFF
--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -29,7 +29,7 @@ python -m cc_tts.speak $ARGUMENTS
 Edit `.cc-voice.toml` in project root:
 
 ```toml
-engine = "auto"        # "piper" | "espeak" | "auto"
+engine = "auto"        # "kokoro" | "piper" | "espeak" | "auto"
 voice = "en_US-amy-medium"
 speed = 1.0
 auto_read = false


### PR DESCRIPTION
One-line doc fix: the `/speak` SKILL.md config comment listed `"piper" | "espeak" | "auto"` but omitted `"kokoro"` which is the highest-priority auto-detect choice and the recommended engine.

```diff
-engine = "auto"        # "piper" | "espeak" | "auto"
+engine = "auto"        # "kokoro" | "piper" | "espeak" | "auto"
```

Pre-existing drift noticed when testing Kokoro after `make setup_kokoro`.

Generated with Claude <noreply@anthropic.com>