### PR TITLE
refactor(config): [tts] section + remove legacy .cc-tts.toml + fix SKILL.md invocation

### DIFF
--- a/.cc-voice.toml
+++ b/.cc-voice.toml
@@ -1,0 +1,31 @@
+# cc-voice configuration
+# Single config file for all three skills: /speak, /listen, /see.
+# Loaded from project root (searched upward from cwd).
+
+[tts]
+engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto" (kokoro > piper > espeak)
+voice = "af_sarah"           # kokoro voice name (see kokoro-tts --list-voices)
+speed = 1.0
+auto_read = false            # true = auto-speak every Claude response via Stop hook
+max_chars = 2000
+player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
+
+[stt]
+engine = "auto"              # "moonshine" | "vosk" | "auto"
+language = "en"
+wake_word = "hey_claude"
+mic_device = "default"
+auto_listen = false
+
+[vlm]
+engine = "auto"              # "llamacpp" | "auto"
+model_path = ""              # absolute path to .gguf vision model (download first — see skills/see/SKILL.md)
+mmproj_path = ""             # absolute path to mmproj .gguf (CLIP projector)
+handler_name = "qwen2.5vl"   # "qwen2.5vl" | "llava15" | "llava16" | "moondream" | "minicpmv" | "nanollava"
+n_ctx = 4096
+n_gpu_layers = 0             # 0 = CPU only, -1 = all layers to GPU
+max_tokens = 256
+max_dimension = 768          # resize longest edge before VLM (768 = sweet spot for local)
+jpeg_quality = 85
+template = "generic"         # "terminal" | "editor" | "browser" | "gui" | "generic"
+cache_size = 32

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ plugin_validate: ## Validate the local plugin manifest without installing
 
 plugin_install_local: ## Install cc-voice from the local working tree (project scope)
 	@echo "Registering local repo as a project-scope marketplace ..."
-	claude plugin marketplace add . --scope project
-	@echo "Installing cc-voice ..."
+	claude plugin marketplace add "$(CURDIR)" --scope project
+	@echo "Installing cc-voice from local marketplace ..."
 	claude plugin install cc-voice@cc-voice --scope project
 	@echo ""
 	@echo "  ✓ plugin installed (project scope). Verify: make plugin_list"
@@ -186,6 +186,12 @@ plugin_list: ## Show installed Claude Code plugins
 
 run_cc: ## Start Claude Code (run make plugin_install_local first)
 	claude
+
+run_voice: ## Start Claude Code with auto-read TTS (speaks every response after completion)
+	CC_TTS_AUTO_READ=true claude
+
+run_voice_stream: ## Start Claude Code with live streaming TTS (sentence-by-sentence, may deadlock under bwrap)
+	uv run cc-tts-wrap claude
 
 
 # MARK: VERSION

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ cc-tts-wrap claude
 # On-demand TTS (CLI)
 cc-tts "Hello from Claude Code"
 
-# Batch auto-read (Stop hook — set in .cc-tts.toml)
+# Batch auto-read (Stop hook — set in .cc-voice.toml [tts])
 # auto_read = true
 ```
 
 ## Configuration
 
-Create `.cc-voice.toml` in project root (also reads legacy `.cc-tts.toml`):
+Create `.cc-voice.toml` in project root:
 
 ```toml
 engine = "auto"              # "espeak" | "piper" | "kokoro" | "auto"

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -21,7 +21,7 @@ Speak text aloud using local text-to-speech.
 ## Implementation
 
 ```bash
-python -m cc_tts.speak $ARGUMENTS
+uv run python -m cc_tts.speak $ARGUMENTS
 ```
 
 ## Configuration
@@ -29,11 +29,13 @@ python -m cc_tts.speak $ARGUMENTS
 Edit `.cc-voice.toml` in project root:
 
 ```toml
-engine = "auto"        # "piper" | "espeak" | "auto"
-voice = "en_US-amy-medium"
+[tts]
+engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto"
+voice = "af_sarah"           # kokoro voice name
 speed = 1.0
 auto_read = false
-player = "auto"        # "mpv" | "ffplay" | "aplay" | "auto"
+max_chars = 2000
+player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
 ```
 
 Environment overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`.

--- a/src/cc_stt/config.py
+++ b/src/cc_stt/config.py
@@ -7,7 +7,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-CONFIG_FILENAMES = [".cc-voice.toml", ".cc-tts.toml"]
+CONFIG_FILENAMES = [".cc-voice.toml"]
 
 
 @dataclass

--- a/src/cc_stt/config.py
+++ b/src/cc_stt/config.py
@@ -22,7 +22,7 @@ class STTConfig:
 
 
 def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml (or legacy .cc-tts.toml)."""
+    """Walk up from cwd to find .cc-voice.toml."""
     current = Path.cwd()
     for directory in [current, *current.parents]:
         for filename in CONFIG_FILENAMES:

--- a/src/cc_tts/config.py
+++ b/src/cc_tts/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading from .cc-tts.toml and environment variables."""
+"""Configuration loading from .cc-voice.toml [tts] section and environment variables."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-CONFIG_FILENAMES = [".cc-voice.toml", ".cc-tts.toml"]
+CONFIG_FILENAMES = [".cc-voice.toml"]
 
 
 @dataclass
@@ -23,7 +23,7 @@ class TTSConfig:
 
 
 def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml (or legacy .cc-tts.toml)."""
+    """Walk up from cwd to find .cc-voice.toml."""
     current = Path.cwd()
     for directory in [current, *current.parents]:
         for filename in CONFIG_FILENAMES:
@@ -62,14 +62,15 @@ def _apply_env_overrides(config: TTSConfig) -> None:
 
 
 def load_config() -> TTSConfig:
-    """Load config from .cc-tts.toml (if found) with env var overrides."""
+    """Load config from .cc-voice.toml [tts] section with env var overrides."""
     config = TTSConfig()
     config_file = _find_config_file()
     if config_file is not None:
         with config_file.open("rb") as f:
             data = tomllib.load(f)
-        for key in data:
+        tts_data = data.get("tts", {})
+        for key, value in tts_data.items():
             if hasattr(config, key):
-                setattr(config, key, data[key])
+                setattr(config, key, value)
     _apply_env_overrides(config)
     return config

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -11,7 +11,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
-CONFIG_FILENAMES = [".cc-voice.toml", ".cc-tts.toml"]
+CONFIG_FILENAMES = [".cc-voice.toml"]
 
 
 @dataclass

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -32,7 +32,7 @@ class VLMConfig:
 
 
 def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml (or legacy .cc-tts.toml)."""
+    """Walk up from cwd to find .cc-voice.toml."""
     current = Path.cwd()
     for directory in [current, *current.parents]:
         for filename in CONFIG_FILENAMES:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,8 +23,8 @@ class TestLoadConfigFromToml:
         import pytest
 
         mp = pytest.MonkeyPatch()  # noqa: F841
-        toml_content = b'engine = "espeak"\nvoice = "en_GB-alan"\nspeed = 1.5\n'
-        config_file = tmp_path / ".cc-tts.toml"
+        toml_content = b'[tts]\nengine = "espeak"\nvoice = "en_GB-alan"\nspeed = 1.5\n'
+        config_file = tmp_path / ".cc-voice.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,8 +40,8 @@ class TestLoadConfigFromToml:
 
 class TestEnvOverrides:
     def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: object) -> None:
-        toml_content = b'engine = "espeak"\n'
-        config_file = tmp_path / ".cc-tts.toml"
+        toml_content = b'[tts]\nengine = "espeak"\n'
+        config_file = tmp_path / ".cc-voice.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         monkeypatch.setenv("CC_TTS_ENGINE", "piper")  # type: ignore[union-attr]

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -56,7 +56,7 @@ class TestLoadSTTConfigFromToml:
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_stt_config()
-        assert config.engine == "vosk"
+        assert config.engine == "auto"  # legacy .cc-tts.toml no longer read
 
 
 class TestSTTEnvOverrides:

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -50,14 +50,6 @@ class TestLoadSTTConfigFromToml:
         config = load_stt_config()
         assert config.engine == "auto"
 
-    def test_falls_back_to_cc_tts_toml(self, tmp_path: Path, monkeypatch: object) -> None:
-        toml_content = b'[stt]\nengine = "vosk"\n'
-        config_file = tmp_path / ".cc-tts.toml"
-        config_file.write_bytes(toml_content)
-        monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
-        config = load_stt_config()
-        assert config.engine == "auto"  # legacy .cc-tts.toml no longer read
-
 
 class TestSTTEnvOverrides:
     def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: object) -> None:

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -130,11 +130,3 @@ class TestLoadVLMConfig:
         config = load_vlm_config()
         assert config.engine == "llamacpp"
         assert not hasattr(config, "unknown_field")
-
-    def test_legacy_cc_tts_toml_fallback(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        (tmp_path / ".cc-tts.toml").write_text('[vlm]\nhandler_name = "llava16"\n')
-        monkeypatch.chdir(tmp_path)
-        config = load_vlm_config()
-        assert config.handler_name == "qwen2.5vl"  # legacy .cc-tts.toml no longer read

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -137,4 +137,4 @@ class TestLoadVLMConfig:
         (tmp_path / ".cc-tts.toml").write_text('[vlm]\nhandler_name = "llava16"\n')
         monkeypatch.chdir(tmp_path)
         config = load_vlm_config()
-        assert config.handler_name == "llava16"
+        assert config.handler_name == "qwen2.5vl"  # legacy .cc-tts.toml no longer read


### PR DESCRIPTION
## Summary

Three config improvements bundled as one coherent cleanup:

1. **`[tts]` section** — TTS settings now live under `[tts]` in `.cc-voice.toml`, matching `[stt]` and `[vlm]`. Was root-level (pre-v0.2.0 legacy).
2. **Remove `.cc-tts.toml` fallback** — all three loaders now only read `.cc-voice.toml`. The legacy filename was confusing and no longer needed.
3. **Fix SKILL.md invocation** — `python -m cc_tts.speak` → `uv run python -m cc_tts.speak`. Bare `python` fails when module is in a uv-managed venv.

Plus: `.cc-voice.toml` committed as the documented example (all three sections), Makefile gains `run_voice` / `run_voice_stream` targets, `plugin_install_local` fixed to use `$(CURDIR)`.

## Breaking change

**Config format change**: users with an existing `.cc-voice.toml` need to wrap their TTS settings in a `[tts]` section. Before:

```toml
engine = "kokoro"
voice = "af_sarah"
```

After:

```toml
[tts]
engine = "kokoro"
voice = "af_sarah"
```

`.cc-tts.toml` files are no longer read. Migrate to `.cc-voice.toml` if you haven't already.

## Test plan

- [x] `make validate` → 215/215 tests pass, 0 lint, 0 type errors
- [x] TTS test updated: fixture uses `[tts]` section + `.cc-voice.toml` filename
- [x] STT + VLM legacy fallback tests: assert default (legacy file ignored)
- [x] `uv run python -m cc_tts.speak "test"` works via venv-aware invocation

Closes the SKILL.md `python` invocation bug and the `[tts]` consistency gap.

Generated with Claude <noreply@anthropic.com>