### PR TITLE
fix(hooks): Stop hook uses uv run instead of broken .venv path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd ${CLAUDE_PLUGIN_ROOT:-.} && .venv/bin/python -m cc_tts.hook_handler",
+            "command": "uv run python -m cc_tts.hook_handler",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
One-line fix: the Stop hook command referenced \`.venv/bin/python\` inside \`CLAUDE_PLUGIN_ROOT\` (the plugin cache), which has no venv. Changed to \`uv run python\` which finds the project's venv from the session cwd.

This is why \`/speak --toggle\` + \`auto_read = true\` wasn't speaking Claude's responses — the hook silently failed on every Stop event because the Python path was wrong.

Tested: \`echo '{"transcript":[...]}' | uv run python -m cc_tts.hook_handler\` speaks the assistant message via Kokoro.

Generated with Claude <noreply@anthropic.com>