### PR TITLE
fix(hooks+stream): team mode, streaming TTS, graceful shutdown

### DIFF
--- a/.cc-voice.toml
+++ b/.cc-voice.toml
@@ -6,7 +6,16 @@
 engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto" (kokoro > piper > espeak)
 voice = "af_sarah"           # kokoro voice name (see kokoro-tts --list-voices)
 speed = 1.0
-auto_read = false            # true = auto-speak every Claude response via Stop hook
+auto_read = true             # true = auto-speak every Claude response via Stop hook
+                             #
+                             # Two TTS modes (do not combine — causes double speaking):
+                             #   Batch (Stop hook):     make run_voice         ~2-5s after response ends
+                             #   Streaming (PTY proxy): make run_voice_stream  ~0.5s, sentence-by-sentence
+                             #
+                             # The Stop hook is always registered in .claude/settings.json
+                             # but is a no-op when auto_read = false (exits in <100ms).
+                             # When true, the handler forks — CC unblocks immediately while
+                             # audio plays in background.
 max_chars = 2000
 player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
 

--- a/.cc-voice.toml
+++ b/.cc-voice.toml
@@ -1,12 +1,19 @@
 # cc-voice configuration
 # Single config file for all three skills: /speak, /listen, /see.
 # Loaded from project root (searched upward from cwd).
+#
+# Every field below can be overridden via environment variable:
+#   [tts]  field → CC_TTS_<FIELD>    e.g. engine → CC_TTS_ENGINE
+#   [stt]  field → CC_STT_<FIELD>    e.g. engine → CC_STT_ENGINE
+#   [vlm]  field → CC_VLM_<FIELD>    e.g. model_path → CC_VLM_MODEL_PATH
+# Env vars take precedence over TOML values. Accepted values and defaults
+# are documented inline per field below.
 
 [tts]
 engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto" (kokoro > piper > espeak)
 voice = "af_sarah"           # kokoro voice name (see kokoro-tts --list-voices)
 speed = 1.0
-auto_read = true             # true = auto-speak every Claude response via Stop hook
+auto_read = false             # true = auto-speak every Claude response via Stop hook
                              #
                              # Two TTS modes (do not combine — causes double speaking):
                              #   Batch (Stop hook):     make run_voice         ~2-5s after response ends

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,9 +18,7 @@
       "Bash(git:status:*)",
       "Bash(git:log:--grep:*)",
       "Bash(git:rev-list:*)",
-      "Bash(jq:*)",
       "Bash(make:*)",
-      "Bash(tree:*)",
       "Edit(docs/)",
       "Edit(tests/)",
       "Edit(src/**)",
@@ -59,10 +57,6 @@
       "Edit(README.md)"
     ]
   },
-  "statusLine": {
-    "type": "command",
-    "command": "bash .claude/scripts/statusline.sh"
-  },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
@@ -70,13 +64,20 @@
     "python-dev@qte77-claude-code-utils": true,
     "commit-helper@qte77-claude-code-utils": true,
     "codebase-tools@qte77-claude-code-utils": true,
-    "cc-meta@qte77-claude-code-utils": true
+    "cc-meta@qte77-claude-code-utils": true,
+    "cc-voice@cc-voice": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-utils": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-utils-plugin"
+      }
+    },
+    "cc-voice": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/cc-voice-plugin-prototype"
       }
     }
   },

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "Stop": [
       {
-        "matcher": "*",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -40,6 +40,17 @@ player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
 
 Environment overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`.
 
+## TTS modes — batch vs streaming
+
+Two ways to auto-speak Claude's responses. **Do not combine** — causes double speaking.
+
+| Mode | Start with | First audio | How it works |
+|---|---|---|---|
+| **Batch (Stop hook)** | `/speak --toggle` or `make run_voice` | ~2-5s after response ends | Stop hook fires → handler forks (CC unblocks) → Kokoro synthesizes full text → plays |
+| **Streaming (PTY proxy)** | `make run_voice_stream` | ~0.5s after first sentence | PTY wrapper intercepts stdout → speaks sentence-by-sentence as Claude types |
+
+**Stop hook latency**: the handler forks immediately so CC accepts input while audio plays in the background. Synthesis time is proportional to response length (~1s per 100 words with Kokoro). For low-latency needs, use streaming mode.
+
 ## Voice Loop (STT + TTS)
 
 Enable auto-read then use CC-native `/voice` for full bidirectional voice:

--- a/src/cc_tts/hook_handler.py
+++ b/src/cc_tts/hook_handler.py
@@ -1,7 +1,7 @@
 """Stop hook handler for auto-read mode.
 
 This hook fires on EVERY Claude response (registered as a Stop hook in
-.claude/settings.json). It is intentionally always-registered rather than
+hooks/hooks.json via the cc-voice plugin). It is intentionally always-registered rather than
 dynamically added/removed because CC hooks don't hot-reload — they require
 a session restart to take effect.
 
@@ -24,11 +24,9 @@ not enable both simultaneously or you'll get double speaking.
 from __future__ import annotations
 
 import json
-import os
 import sys
 
 from cc_tts.config import load_config
-from cc_tts.speak import synthesize_and_play
 
 
 def extract_assistant_text(stdin_data: str) -> str:
@@ -49,8 +47,15 @@ def main() -> None:
 
     Forks after extracting text: parent exits immediately so CC unblocks,
     child synthesizes and plays in background.
+
+    Graceful no-op when deps are missing (team members without TTS setup).
     """
-    config = load_config()
+    try:
+        config = load_config()
+    except Exception:
+        # Config or TTS modules not available — deps not installed.
+        return
+
     if not config.auto_read:
         return
 
@@ -59,18 +64,26 @@ def main() -> None:
     if not text:
         return
 
-    # Fork: parent returns immediately (CC unblocks), child speaks in background.
-    pid = os.fork()
-    if pid != 0:
+    # Launch TTS in a detached subprocess so CC can't kill it when the
+    # hook shell exits. os.fork() doesn't work here because CC kills the
+    # entire process group on hook completion — the forked child dies
+    # before it can synthesize audio. subprocess.Popen with
+    # start_new_session=True creates an independent session/process group.
+    import shutil
+    import subprocess
+
+    if shutil.which("uv") is None:
         return
 
-    # Child process: synthesize and play, then exit.
     try:
-        synthesize_and_play(text, config=config)
-    except Exception:
-        pass  # noqa: S110 — child must not propagate exceptions to CC
-    finally:
-        os._exit(0)
+        subprocess.Popen(
+            ["uv", "run", "python", "-m", "cc_tts.speak", text],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        return
 
 
 if __name__ == "__main__":

--- a/src/cc_tts/hook_handler.py
+++ b/src/cc_tts/hook_handler.py
@@ -1,8 +1,30 @@
-"""Stop hook handler for auto-read mode."""
+"""Stop hook handler for auto-read mode.
+
+This hook fires on EVERY Claude response (registered as a Stop hook in
+.claude/settings.json). It is intentionally always-registered rather than
+dynamically added/removed because CC hooks don't hot-reload — they require
+a session restart to take effect.
+
+The cost is negligible when auto_read = false (the default): the handler
+loads config, sees auto_read is off, and exits immediately (~200ms Python
+startup, no audio processing). Only when auto_read = true does it extract
+the assistant's response and speak it.
+
+Performance: the handler forks immediately after extracting the text. The
+parent exits (~100ms) so CC unblocks and accepts the next user input. The
+child process synthesizes and plays audio in the background. This means
+the user can type while the previous response is still being spoken.
+
+Latency: batch mode — speaks AFTER the full response is generated, not
+during. For streaming TTS (sentence-by-sentence as Claude types), use the
+PTY wrapper instead: `make run_voice_stream` / `cc-tts-wrap claude`. Do
+not enable both simultaneously or you'll get double speaking.
+"""
 
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 from cc_tts.config import load_config
@@ -10,33 +32,45 @@ from cc_tts.speak import synthesize_and_play
 
 
 def extract_assistant_text(stdin_data: str) -> str:
-    """Extract the last assistant message from hook JSON payload."""
+    """Extract the last assistant message from CC Stop hook JSON payload.
+
+    CC sends: {"last_assistant_message": "...", "session_id": "...", ...}
+    """
     try:
         payload = json.loads(stdin_data)
     except (json.JSONDecodeError, TypeError):
         return ""
 
-    transcript = payload.get("transcript", [])
-    if not transcript:
-        return ""
-
-    for msg in reversed(transcript):
-        if msg.get("role") == "assistant":
-            return str(msg.get("content", ""))
-
-    return ""
+    return str(payload.get("last_assistant_message", ""))
 
 
 def main() -> None:
-    """Entry point for the Stop hook. Reads stdin, speaks if auto_read enabled."""
+    """Entry point for the Stop hook. Reads stdin, speaks if auto_read enabled.
+
+    Forks after extracting text: parent exits immediately so CC unblocks,
+    child synthesizes and plays in background.
+    """
     config = load_config()
     if not config.auto_read:
         return
 
     stdin_data = sys.stdin.read()
     text = extract_assistant_text(stdin_data)
-    if text:
+    if not text:
+        return
+
+    # Fork: parent returns immediately (CC unblocks), child speaks in background.
+    pid = os.fork()
+    if pid != 0:
+        return
+
+    # Child process: synthesize and play, then exit.
+    try:
         synthesize_and_play(text, config=config)
+    except Exception:
+        pass  # noqa: S110 — child must not propagate exceptions to CC
+    finally:
+        os._exit(0)
 
 
 if __name__ == "__main__":

--- a/src/cc_tts/pty_proxy.py
+++ b/src/cc_tts/pty_proxy.py
@@ -31,10 +31,13 @@ def _tts_worker(
         sentence = q.get()
         if sentence is None:
             break
-        if on_speak is not None:
-            on_speak(sentence)
-        else:
-            synthesize_and_play(sentence)
+        try:
+            if on_speak is not None:
+                on_speak(sentence)
+            else:
+                synthesize_and_play(sentence)
+        except Exception as exc:
+            print(f"[cc-voice] TTS error: {exc}", file=sys.stderr)
 
 
 def _get_winsize(fd: int) -> bytes:
@@ -160,12 +163,17 @@ def run_pty_proxy(
 
     try:
         _proxy_loop(master_fd, stdin_fd, is_tty, stream_filter)
+    except KeyboardInterrupt:
+        pass
     finally:
         if old_attrs is not None:
             termios.tcsetattr(stdin_fd, termios.TCSAFLUSH, old_attrs)
         stream_filter.finish()
         tts_queue.put(None)
-        worker.join(timeout=30)
+        try:
+            worker.join(timeout=5)
+        except KeyboardInterrupt:
+            pass
 
     _, status = os.waitpid(pid, 0)
     return os.waitstatus_to_exitcode(status)

--- a/src/cc_tts/speak.py
+++ b/src/cc_tts/speak.py
@@ -51,11 +51,53 @@ def synthesize_and_play(text: str, config: TTSConfig | None = None) -> None:
             print(f"No audio device. WAV saved: {f.name}", file=sys.stderr)
 
 
-def main() -> None:
-    """CLI entry point for cc-tts."""
-    if len(sys.argv) < 2:
-        print("Usage: cc-tts <text>", file=sys.stderr)
+def _toggle_auto_read() -> None:
+    """Toggle auto_read in .cc-voice.toml [tts] section."""
+    from cc_tts.config import _find_config_file  # pyright: ignore[reportPrivateUsage]
+
+    config_path = _find_config_file()
+    if config_path is None:
+        print("No .cc-voice.toml found — create one first", file=sys.stderr)
         sys.exit(1)
+
+    content = config_path.read_text()
+    if "auto_read = true" in content:
+        content = content.replace("auto_read = true", "auto_read = false", 1)
+        print("auto_read: true → false")
+    elif "auto_read = false" in content:
+        content = content.replace("auto_read = false", "auto_read = true", 1)
+        print("auto_read: false → true")
+    else:
+        print("auto_read field not found in .cc-voice.toml [tts] section", file=sys.stderr)
+        sys.exit(1)
+    config_path.write_text(content)
+
+
+def main() -> None:
+    """CLI entry point for cc-voice speak.
+
+    Usage:
+        python -m cc_tts.speak <text>       speak the given text
+        python -m cc_tts.speak --toggle     flip auto_read in .cc-voice.toml
+        python -m cc_tts.speak --help       show usage
+    """
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print("Usage: python -m cc_tts.speak [--toggle | --help | <text to speak>]")
+        print("  <text>    Speak the given text via the configured TTS engine")
+        print("  --toggle  Flip auto_read in .cc-voice.toml (enables/disables Stop hook TTS)")
+        print("  --help    Show this message")
+        return
+
+    if "--toggle" in sys.argv:
+        _toggle_auto_read()
+        return
+
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python -m cc_tts.speak [--toggle | --help | <text to speak>]", file=sys.stderr
+        )
+        sys.exit(1)
+
     text = " ".join(sys.argv[1:])
     synthesize_and_play(text)
 

--- a/src/cc_tts/stream_filter.py
+++ b/src/cc_tts/stream_filter.py
@@ -7,7 +7,7 @@ import re
 from cc_tts.sentence_buffer import SentenceBuffer
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b\].*?\x07")
-_BOX_DRAWING = re.compile(r"[│─┌┐└┘├┤┬┴┼]")
+_PRINTABLE_ASCII = re.compile(r"[^\x20-\x7e]")
 
 
 def _is_nonalpha_line(line: str) -> bool:
@@ -50,13 +50,12 @@ class StreamFilter:
 
         clean = _ANSI_ESCAPE.sub("", text)
 
-        # Normalize PTY line endings (\r\n → \n) before splitting
+        # Normalize PTY line endings, then emulate terminal \r semantics:
+        # \r means "overwrite from start of line" — keep only text after last \r.
         clean = clean.replace("\r\n", "\n")
+        clean = re.sub(r"[^\n]*\r", "", clean)
 
         for line in clean.split("\n"):
-            # Spinner detection: lines with remaining CR are overwrites — skip entirely
-            if "\r" in line:
-                continue
 
             # Code block toggle
             stripped = line.strip()
@@ -67,9 +66,8 @@ class StreamFilter:
             if self._in_code_block:
                 continue
 
-            # Tool output: box-drawing characters
-            if _BOX_DRAWING.search(line):
-                continue
+            # Keep only printable ASCII (drops box-drawing, emoji, etc.)
+            stripped = _PRINTABLE_ASCII.sub("", stripped).strip()
 
             # High non-alpha lines (diffs, separators)
             if _is_nonalpha_line(stripped):

--- a/tests/test_hook_handler.py
+++ b/tests/test_hook_handler.py
@@ -1,4 +1,4 @@
-"""Tests for cc_tts.hook_handler — TDD RED phase."""
+"""Tests for cc_tts.hook_handler — extracts assistant text from CC Stop hook payload."""
 
 from __future__ import annotations
 
@@ -8,38 +8,30 @@ from cc_tts.hook_handler import extract_assistant_text
 
 
 class TestExtractAssistantText:
-    def test_extracts_text_from_stop_event(self) -> None:
+    def test_extracts_last_assistant_message(self) -> None:
+        """CC Stop hook sends last_assistant_message as a top-level field."""
         payload = {
             "session_id": "abc",
-            "stop_hook_active": True,
-            "transcript": [
-                {"role": "assistant", "content": "Hello from Claude."},
-            ],
+            "hook_event_name": "Stop",
+            "last_assistant_message": "Hello from Claude.",
         }
         result = extract_assistant_text(json.dumps(payload))
         assert result == "Hello from Claude."
 
-    def test_returns_empty_for_no_transcript(self) -> None:
-        payload = {"session_id": "abc"}
+    def test_returns_empty_when_field_missing(self) -> None:
+        payload = {"session_id": "abc", "hook_event_name": "Stop"}
         result = extract_assistant_text(json.dumps(payload))
         assert result == ""
 
-    def test_returns_empty_for_empty_transcript(self) -> None:
-        payload = {"session_id": "abc", "transcript": []}
+    def test_returns_empty_for_empty_message(self) -> None:
+        payload = {"last_assistant_message": ""}
         result = extract_assistant_text(json.dumps(payload))
         assert result == ""
-
-    def test_returns_last_assistant_message(self) -> None:
-        payload = {
-            "transcript": [
-                {"role": "user", "content": "hi"},
-                {"role": "assistant", "content": "first"},
-                {"role": "assistant", "content": "second"},
-            ],
-        }
-        result = extract_assistant_text(json.dumps(payload))
-        assert result == "second"
 
     def test_handles_invalid_json(self) -> None:
         result = extract_assistant_text("not json")
+        assert result == ""
+
+    def test_handles_empty_input(self) -> None:
+        result = extract_assistant_text("")
         assert result == ""

--- a/tests/test_pty_proxy.py
+++ b/tests/test_pty_proxy.py
@@ -28,6 +28,38 @@ class TestTtsWorker:
         assert spoken == ["First.", "Second."]
 
 
+    def test_worker_survives_callback_error(self) -> None:
+        spoken: list[str] = []
+        call_count = 0
+
+        def flaky_speak(sentence: str) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("engine exploded")
+            spoken.append(sentence)
+
+        q: queue.Queue[str | None] = queue.Queue()
+        q.put("Boom.")
+        q.put("Survives.")
+        q.put(None)
+
+        _tts_worker(q, on_speak=flaky_speak)
+        assert spoken == ["Survives."]
+
+    def test_worker_handles_sigint_in_subprocess(self) -> None:
+        import subprocess
+
+        def sigint_speak(sentence: str) -> None:
+            raise subprocess.CalledProcessError(-2, "kokoro-tts")
+
+        q: queue.Queue[str | None] = queue.Queue()
+        q.put("Interrupted.")
+        q.put(None)
+
+        _tts_worker(q, on_speak=sigint_speak)  # must not raise
+
+
 class TestPtyProxy:
     def test_captures_echo_output(self) -> None:
         spoken: list[str] = []

--- a/tests/test_stream_filter.py
+++ b/tests/test_stream_filter.py
@@ -51,11 +51,16 @@ class TestCodeBlockSkip:
 
 
 class TestToolOutputSkip:
-    def test_skips_box_drawing_lines(self) -> None:
+    def test_skips_pure_border_lines(self) -> None:
         sf, sentences = _make_filter()
-        sf.feed(b"Answer. \n\xe2\x94\x82 tool output\n")
+        sf.feed(b"\xe2\x94\x8c\xe2\x94\x80\xe2\x94\x80\xe2\x94\x90\n")
         sf.buffer.flush()
-        assert "tool output" not in " ".join(sentences)
+        assert sentences == []
+
+    def test_strips_border_keeps_text(self) -> None:
+        sf, sentences = _make_filter()
+        sf.feed(b"\xe2\x94\x82 Hello world. ")
+        assert sentences == ["Hello world."]
 
     def test_skips_high_nonalpha_lines(self) -> None:
         sf, sentences = _make_filter()
@@ -67,11 +72,31 @@ class TestToolOutputSkip:
 class TestSpinnerSkip:
     def test_skips_carriage_return_lines(self) -> None:
         sf, sentences = _make_filter()
-        sf.feed(b"\rSpinning...")
-        sf.feed(b"\rDone.\n")
+        sf.feed(b"Progress 50%...\rProgress 100%\n")
         sf.buffer.flush()
-        # Spinner lines with CR but no preceding NL should be skipped
+        assert "50%" not in " ".join(sentences)
+
+
+class TestInkFrames:
+    def test_ink_frame_produces_speech(self) -> None:
+        """Ink-style \\x1b[2K\\r<text>\\r\\n must not be silenced."""
+        sf, sentences = _make_filter()
+        sf.feed(b"\x1b[2K\rHello world.\r\n")
+        sf.buffer.flush()
+        assert sentences == ["Hello world."]
+
+    def test_multi_overwrite_keeps_last(self) -> None:
+        sf, sentences = _make_filter()
+        sf.feed(b"old\rnew\rfinal text.\r\n")
+        sf.buffer.flush()
+        assert sentences == ["final text."]
+
+    def test_spinner_overwrite_keeps_final(self) -> None:
+        sf, sentences = _make_filter()
+        sf.feed(b"Spinning...\rDone.\n")
+        sf.buffer.flush()
         assert "Spinning" not in " ".join(sentences)
+        assert "Done." in sentences
 
 
 class TestFinish:


### PR DESCRIPTION
## Summary

- **Team mode settings cleanup**: Remove debug Stop hook, statusLine, and personal permissions from shared `settings.json`. Fix marketplace source from hardcoded absolute path to GitHub repo. Add graceful no-op guards to `hook_handler.py` for team members without TTS deps.
- **Stream filter robustness**: Replace box-drawing char blacklist with ASCII printable whitelist. Emulate terminal `\r` semantics (`re.sub` keeps only text after last CR) — fixes streaming TTS silence caused by Ink-rendered output.
- **Worker resilience**: Wrap `synthesize_and_play()` in try/except so one bad sentence doesn't kill the TTS worker thread for the entire session.
- **Graceful Ctrl+C**: Catch `KeyboardInterrupt` in proxy loop and `worker.join` to suppress SIGINT tracebacks. Reduce join timeout from 30s to 5s.

## Test plan

- [x] `make validate` passes (219 tests, lint, type check)
- [ ] `make run_voice_stream` — audio plays sentence-by-sentence
- [ ] Ctrl+C during streaming — clean exit, no traceback
- [ ] `auto_read=false` (default) — Stop hook is silent no-op
- [ ] `settings.json` has no absolute paths or debug artifacts

Generated with Claude <noreply@anthropic.com>