### PR TITLE
chore: README env var fix + --speed flag for cc-tts-stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mic_device = "default"
 auto_listen = false
 ```
 
-TTS env overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`, `CC_TTS_PLAYER`.
+TTS env overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`, `CC_TTS_MAX_CHARS`, `CC_TTS_PLAYER`.
 
 STT env overrides: `CC_STT_ENGINE`, `CC_STT_LANGUAGE`, `CC_STT_WAKE_WORD`, `CC_STT_MIC_DEVICE`, `CC_STT_AUTO_LISTEN`.
 

--- a/src/cc_tts/stream_json.py
+++ b/src/cc_tts/stream_json.py
@@ -74,15 +74,28 @@ def main() -> None:
     Sends prompt to Claude via stream-json, speaks response sentences as they arrive.
     """
     if len(sys.argv) < 2 or "--help" in sys.argv or "-h" in sys.argv:
-        print("Usage: cc-tts-stream <prompt>")
+        print("Usage: cc-tts-stream [--speed <float>] <prompt>")
         print("  Sends prompt to Claude, speaks the response via TTS.")
+        print("  --speed  Override TTS speed (default: from .cc-voice.toml)")
         sys.exit(0 if "--help" in sys.argv or "-h" in sys.argv else 1)
 
     if shutil.which("claude") is None:
         print("Error: 'claude' CLI not found on PATH.", file=sys.stderr)
         sys.exit(1)
 
-    prompt = " ".join(sys.argv[1:])
+    # Parse --speed flag
+    args = sys.argv[1:]
+    speed_override: float | None = None
+    if "--speed" in args:
+        idx = args.index("--speed")
+        try:
+            speed_override = float(args[idx + 1])
+            args = args[:idx] + args[idx + 2 :]
+        except (IndexError, ValueError):
+            print("Error: --speed requires a numeric value", file=sys.stderr)
+            sys.exit(1)
+
+    prompt = " ".join(args)
 
     proc = subprocess.Popen(
         [
@@ -122,8 +135,9 @@ def main() -> None:
     response = "".join(full_text).strip()
     if response:
         config = load_config()
+        speed = speed_override if speed_override is not None else config.speed
         speak_streaming(
-            response, voice=config.voice, speed=config.speed, engine=config.engine,
+            response, voice=config.voice, speed=speed, engine=config.engine,
         )
 
 


### PR DESCRIPTION
## Summary

- Add missing `CC_TTS_MAX_CHARS` to README env var list
- Add `--speed <float>` CLI flag to `cc-tts-stream` for quick speed override
- Delete stale remote branches (wip/pty-stream-filter-ink-markers, feat/stream-json-tts)

## Test plan

- [x] `make validate` passes (231 tests)
- [ ] `uv run cc-tts-stream --speed 1.5 "Hello fast."` — faster playback
- [ ] `uv run cc-tts-stream --help` — shows --speed usage

Generated with Claude <noreply@anthropic.com>