### PR TITLE
chore: rename plugin references to claude-code-plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,18 +60,18 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "tdd-core@qte77-claude-code-utils": true,
-    "python-dev@qte77-claude-code-utils": true,
-    "commit-helper@qte77-claude-code-utils": true,
-    "codebase-tools@qte77-claude-code-utils": true,
-    "cc-meta@qte77-claude-code-utils": true,
+    "tdd-core@qte77-claude-code-plugins": true,
+    "python-dev@qte77-claude-code-plugins": true,
+    "commit-helper@qte77-claude-code-plugins": true,
+    "codebase-tools@qte77-claude-code-plugins": true,
+    "cc-meta@qte77-claude-code-plugins": true,
     "cc-voice@cc-voice": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "qte77/claude-code-utils-plugin"
+        "repo": "qte77/claude-code-plugins"
       }
     },
     "cc-voice": {


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` and `qte77-claude-code-utils` → `qte77-claude-code-plugins`

Follows GitHub repo rename qte77/claude-code-utils-plugin → qte77/claude-code-plugins.

🤖 Generated with Claude <noreply@anthropic.com>