### PR TITLE
feat(tts): --stop interrupt + markdown in streaming path + hotkey docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,28 @@ speak.py → engine.synthesize() → player.play_audio()
 
 ### How to interrupt voice playback
 
-No clean interrupt command yet. Brute-force options:
-
 ```bash
-pkill -f "cc_tts.speak"      # kill the speak subprocess
-pkill -f "mpv|ffplay"         # kill the audio player
-pkill -f "kokoro-tts|piper"   # kill the TTS engine
+uv run cc-tts --stop
 ```
 
-FIXME: proper `cc-tts --stop` (PID file + `killpg`) is planned — see issue tracker.
+Reads the PID file at `~/.cache/cc-voice/speak.pid` and sends SIGTERM to the whole process group (engine + player + children). Works for all delivery modes (Stop hook, stream-json, PTY proxy) — any mode writes the pidfile on start.
+
+**Bind to a hotkey** (no code change needed). Pick a key not already used by your shell/editors. Common available choices: Alt+s, F8, Ctrl+\\:
+
+```bash
+# bash — Alt+s (\\es)
+bind -x '"\es":"uv run cc-tts --stop"'
+
+# zsh — Alt+s
+cc-tts-stop() { uv run cc-tts --stop }
+zle -N cc-tts-stop
+bindkey '^[s' cc-tts-stop
+
+# tmux — prefix + s (or global with -n)
+bind-key s run-shell "uv run cc-tts --stop"
+```
+
+Avoid Ctrl+G (opens nano help), Ctrl+C (sends SIGINT), Ctrl+D (EOF), Ctrl+Z (suspend).
 
 ## Development
 

--- a/src/cc_tts/edge_stream.py
+++ b/src/cc_tts/edge_stream.py
@@ -13,6 +13,13 @@ def speak_streaming(
     text: str, *, voice: str = "en-US-AriaNeural", speed: float = 1.0, engine: str = "auto"
 ) -> None:
     """Synthesize and play text, streaming audio to player where possible."""
+    from cc_tts.preprocess import preprocess
+
+    # Strip markdown, code blocks, URLs so TTS doesn't read "hash hash What we lose".
+    text = preprocess(text)
+    if not text:
+        return
+
     if engine == "auto":
         # Priority: kokoro (best local) > piper > espeak > edge-tts (cloud, last resort)
         _fallbacks = [("kokoro-tts", "kokoro"), ("piper", "piper"), ("espeak-ng", "espeak")]

--- a/src/cc_tts/preprocess.py
+++ b/src/cc_tts/preprocess.py
@@ -13,6 +13,9 @@ def preprocess(text: str, *, max_chars: int = 2000) -> str:
     # Inline code
     text = re.sub(r"`[^`]+`", lambda m: m.group(0).strip("`"), text)
 
+    # Markdown links [text](url) → text (do this BEFORE URL-only replacement)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+
     # URLs
     text = re.sub(r"https?://\S+", "link", text)
 
@@ -21,6 +24,18 @@ def preprocess(text: str, *, max_chars: int = 2000) -> str:
 
     # Bold and italic
     text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)
+
+    # Table rows: drop lines that are entirely pipes / dashes / whitespace
+    text = re.sub(r"^\s*\|[\s\-|:]+\|\s*$", "", text, flags=re.MULTILINE)
+    # Table content: strip leading/trailing | and convert inner | to comma
+    text = re.sub(r"^\s*\|\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s*\|\s*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s*\|\s*", ", ", text)
+
+    # List markers (-, *, +) at line start
+    text = re.sub(r"^\s*[-*+]\s+", "", text, flags=re.MULTILINE)
+    # Numbered list markers (1., 2., etc.) at line start
+    text = re.sub(r"^\s*\d+\.\s+", "", text, flags=re.MULTILINE)
 
     # Collapse whitespace
     text = re.sub(r"\n{3,}", "\n\n", text)

--- a/src/cc_tts/speak.py
+++ b/src/cc_tts/speak.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import atexit
 import os
+import signal
 import sys
 import tempfile
 from pathlib import Path
@@ -13,6 +15,46 @@ from cc_tts.player import NoAudioDeviceError, play_audio
 from cc_tts.preprocess import preprocess
 
 _output_counter = 0
+
+# PID file for --stop interrupt. Stores the current speak PGID (process group).
+_PID_FILE = Path.home() / ".cache" / "cc-voice" / "speak.pid"
+
+
+def _write_pidfile() -> None:
+    """Write current process group ID to pidfile for --stop to find."""
+    _PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    pgid = os.getpgrp()
+    _PID_FILE.write_text(str(pgid))
+    atexit.register(_clear_pidfile)
+
+
+def _clear_pidfile() -> None:
+    """Remove pidfile on clean exit."""
+    try:
+        _PID_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _stop_playback() -> int:
+    """Read pidfile, kill process group, clear pidfile. Returns exit code."""
+    if not _PID_FILE.exists():
+        print("No TTS playback running (no pidfile).", file=sys.stderr)
+        return 1
+    try:
+        pgid = int(_PID_FILE.read_text().strip())
+    except (OSError, ValueError) as exc:
+        print(f"Invalid pidfile: {exc}", file=sys.stderr)
+        _clear_pidfile()
+        return 1
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+        print(f"Stopped TTS playback (pgid={pgid})")
+    except ProcessLookupError:
+        print("TTS playback already exited.", file=sys.stderr)
+    finally:
+        _clear_pidfile()
+    return 0
 
 
 def _next_output_path(output_dir: Path) -> str:
@@ -82,11 +124,16 @@ def main() -> None:
         python -m cc_tts.speak --help       show usage
     """
     if "--help" in sys.argv or "-h" in sys.argv:
-        print("Usage: python -m cc_tts.speak [--toggle | --help | <text to speak>]")
+        print("Usage: python -m cc_tts.speak [--toggle | --stop | --stream | <text>]")
         print("  <text>    Speak the given text via the configured TTS engine")
+        print("  --stream  Stream audio directly to player (no temp files)")
+        print("  --stop    Interrupt ongoing TTS playback (SIGTERM to process group)")
         print("  --toggle  Flip auto_read in .cc-voice.toml (enables/disables Stop hook TTS)")
         print("  --help    Show this message")
         return
+
+    if "--stop" in sys.argv:
+        sys.exit(_stop_playback())
 
     if "--toggle" in sys.argv:
         _toggle_auto_read()
@@ -101,6 +148,8 @@ def main() -> None:
     stream = "--stream" in sys.argv
     args = [a for a in sys.argv[1:] if a != "--stream"]
     text = " ".join(args)
+
+    _write_pidfile()
 
     if stream:
         from cc_tts.edge_stream import speak_streaming


### PR DESCRIPTION
## Summary

- **`cc-tts --stop`** interrupts ongoing TTS playback by sending SIGTERM to the process group. PID file at `~/.cache/cc-voice/speak.pid`, cleared via atexit on clean exit.
- **Markdown preprocessing in streaming path**: `speak_streaming()` was skipping `preprocess()`, so TTS literally read "hash hash What" for markdown headers and "pipe pipe" for tables. Now strips tables, lists, links, headers, code blocks in all streaming engines.
- **Hotkey binding docs**: bash/zsh/tmux examples for binding `cc-tts --stop` to a key. Works for all delivery modes (Stop hook, stream-json, PTY proxy) via shared pidfile.

## Test plan

- [x] `make validate` passes (231 tests)
- [x] `uv run cc-tts --stream "long text" & sleep 2 && uv run cc-tts --stop` — audio cuts off
- [x] Markdown response (tables, headers, lists) spoken cleanly without literal punctuation
- [ ] In interactive Claude with auto_read=true, run `! uv run cc-tts --stop` to interrupt

## Stacked on

Rebased onto #49 (already merged).

Generated with Claude <noreply@anthropic.com>