### PR TITLE
feat(repl): cc-tts-repl — interactive stream-json REPL with TTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,12 @@ run_voice_stream_json: ## Speak Claude response via stream-json (non-interactive
 	@test -n "$(PROMPT)" || { echo "Usage: make run_voice_stream_json PROMPT='your question'"; exit 1; }
 	uv run cc-tts-stream "$(PROMPT)"
 
+run_repl: ## Interactive REPL with stream-json TTS (no Ink UI, sandbox-safe)
+	uv run cc-tts-repl
+
+reinstall_plugin: ## Force-reinstall cc-voice plugin (busts stale cache)
+	claude plugin install cc-voice@cc-voice --force
+
 
 # MARK: VERSION
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ test = ["pytest>=9.0.3", "pytest-cov>=6.0"]
 cc-tts = "cc_tts.speak:main"              # speak text: cc-tts "hello"  |  cc-tts --toggle
 cc-tts-wrap = "cc_tts.pty_proxy:main"     # PTY proxy: cc-tts-wrap claude (interactive, fragile)
 cc-tts-stream = "cc_tts.stream_json:main" # stream-json: cc-tts-stream "prompt" (non-interactive, robust)
+cc-tts-repl = "cc_tts.repl:main"         # REPL: cc-tts-repl (interactive stream-json + TTS)
 
 [build-system]
 requires = ["hatchling"]

--- a/src/cc_tts/repl.py
+++ b/src/cc_tts/repl.py
@@ -1,0 +1,141 @@
+"""Bidirectional stream-json REPL with TTS — interactive Claude without PTY."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import threading
+
+from cc_tts.config import load_config
+from cc_tts.edge_stream import speak_streaming
+from cc_tts.speak import _stop_playback  # pyright: ignore[reportPrivateUsage]
+from cc_tts.stream_json import parse_stream_event
+
+_LOCAL_COMMANDS = {"exit", "stop", "toggle"}
+
+
+def parse_local_command(text: str) -> str | None:
+    """Return local command name if text is a local slash command, else None."""
+    stripped = text.strip()
+    if stripped.startswith("/"):
+        cmd = stripped[1:].split()[0].lower() if stripped[1:] else ""
+        if cmd in _LOCAL_COMMANDS:
+            return cmd
+    return None
+
+
+def format_user_message(text: str) -> str:
+    """Format user text as a stream-json user message."""
+    return json.dumps({
+        "type": "user",
+        "message": {"role": "user", "content": text},
+    })
+
+
+def main() -> None:
+    """REPL loop: user input → claude stdin (JSON) → read deltas → print + TTS."""
+    if shutil.which("claude") is None:
+        print("Error: 'claude' CLI not found on PATH.", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_config()
+    auto_read = config.auto_read
+
+    proc = subprocess.Popen(
+        [
+            "claude", "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+
+    # Response-complete event — set when reader sees message_stop for current turn
+    turn_done = threading.Event()
+    response_text: list[str] = []
+
+    def _reader() -> None:
+        """Read claude stdout line-by-line, print text deltas, signal turn completion."""
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            text = parse_stream_event(line)
+            if text is not None:
+                response_text.append(text)
+                sys.stdout.write(text)
+                sys.stdout.flush()
+                continue
+
+            # Check for message_stop (end of turn) or result (final)
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            etype = event.get("event", {}).get("type") or event.get("type")
+            if etype in ("message_stop", "result"):
+                turn_done.set()
+
+    reader_thread = threading.Thread(target=_reader, daemon=True)
+    reader_thread.start()
+
+    print("cc-voice REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read")
+    print()
+
+    try:
+        while True:
+            try:
+                user_input = input("user> ")
+            except (EOFError, KeyboardInterrupt):
+                break
+
+            if not user_input.strip():
+                continue
+
+            cmd = parse_local_command(user_input)
+            if cmd == "exit":
+                break
+            if cmd == "stop":
+                _stop_playback()
+                continue
+            if cmd == "toggle":
+                auto_read = not auto_read
+                print(f"auto_read: {'on' if auto_read else 'off'}")
+                continue
+
+            # Send to claude
+            response_text.clear()
+            turn_done.clear()
+            msg = format_user_message(user_input) + "\n"
+            proc.stdin.write(msg)
+            proc.stdin.flush()
+
+            # Wait for response to complete
+            sys.stdout.write("\n")
+            turn_done.wait(timeout=120)
+            sys.stdout.write("\n\n")
+
+            # Speak full response
+            if auto_read and response_text:
+                full = "".join(response_text).strip()
+                if full:
+                    speak_streaming(
+                        full, voice=config.voice, speed=config.speed, engine=config.engine,
+                    )
+    except KeyboardInterrupt:
+        pass
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,42 @@
+"""Tests for cc_tts.repl — bidirectional stream-json REPL."""
+
+from __future__ import annotations
+
+import json
+
+from cc_tts.repl import format_user_message, parse_local_command
+
+
+class TestParseLocalCommand:
+    def test_exit_recognized(self) -> None:
+        assert parse_local_command("/exit") == "exit"
+
+    def test_stop_recognized(self) -> None:
+        assert parse_local_command("/stop") == "stop"
+
+    def test_toggle_recognized(self) -> None:
+        assert parse_local_command("/toggle") == "toggle"
+
+    def test_plain_text_returns_none(self) -> None:
+        assert parse_local_command("hello world") is None
+
+    def test_unknown_slash_returns_none(self) -> None:
+        """Unknown /commands forwarded to claude, not intercepted."""
+        assert parse_local_command("/commit") is None
+
+    def test_whitespace_stripped(self) -> None:
+        assert parse_local_command("  /exit  ") == "exit"
+
+
+class TestFormatUserMessage:
+    def test_formats_as_stream_json(self) -> None:
+        msg = format_user_message("hello")
+        parsed = json.loads(msg)
+        assert parsed["type"] == "user"
+        assert parsed["message"]["role"] == "user"
+        assert parsed["message"]["content"] == "hello"
+
+    def test_preserves_text(self) -> None:
+        msg = format_user_message("tell me a joke with \"quotes\"")
+        parsed = json.loads(msg)
+        assert parsed["message"]["content"] == 'tell me a joke with "quotes"'


### PR DESCRIPTION
## Summary

Interactive REPL using Claude Code's bidirectional stream-json mode. Replaces the fragile PTY proxy (#2, closed) for interactive streaming TTS.

- Multi-turn conversation via same claude subprocess (no session re-creation)
- Stream `text_delta` events to terminal + speak via `speak_streaming()`
- Local slash commands: `/exit`, `/stop` (interrupt TTS), `/toggle` (auto-read)
- All other input forwarded to claude (including CC slash commands)
- Sandbox-safe — no PTY fork, no bwrap deadlock
- New entry point: `cc-tts-repl` in pyproject.toml
- New Makefile targets: `run_repl`, `reinstall_plugin`

Closes #51

## Test plan

- [x] `make validate` passes (239 tests)
- [ ] `uv run cc-tts-repl` — multi-turn conversation with TTS
- [ ] `/stop` interrupts TTS mid-playback
- [ ] `/toggle` enables/disables auto-read
- [ ] `/exit` clean shutdown
- [ ] `make reinstall_plugin` — force cache bust

Generated with Claude <noreply@anthropic.com>