### PR TITLE
refactor(repl): extract read_stream_events from main() (#55)

### DIFF
--- a/src/cc_tts/repl.py
+++ b/src/cc_tts/repl.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import threading
+from collections.abc import Callable, Iterable
 
 from cc_tts.config import load_config
 from cc_tts.edge_stream import speak_streaming
@@ -28,26 +29,47 @@ def parse_local_command(text: str) -> str | None:
 
 def format_user_message(text: str) -> str:
     """Format user text as a stream-json user message."""
-    return json.dumps({
-        "type": "user",
-        "message": {"role": "user", "content": text},
-    })
+    return json.dumps(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": text},
+        }
+    )
 
 
-def main() -> None:
-    """REPL loop: user input → claude stdin (JSON) → read deltas → print + TTS."""
+def read_stream_events(
+    stdout: Iterable[str],
+    on_text: Callable[[str], None],
+    turn_done: threading.Event,
+) -> None:
+    """Read claude stdout line-by-line, call on_text for deltas, set turn_done on stop."""
+    for line in stdout:
+        text = parse_stream_event(line)
+        if text is not None:
+            on_text(text)
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        etype = event.get("event", {}).get("type") or event.get("type")
+        if etype in ("message_stop", "result"):
+            turn_done.set()
+
+
+def _start_claude() -> subprocess.Popen[str]:
+    """Launch claude in stream-json mode; exits if claude is not on PATH."""
     if shutil.which("claude") is None:
         print("Error: 'claude' CLI not found on PATH.", file=sys.stderr)
         sys.exit(1)
-
-    config = load_config()
-    auto_read = config.auto_read
-
-    proc = subprocess.Popen(
+    return subprocess.Popen(
         [
-            "claude", "-p",
-            "--input-format", "stream-json",
-            "--output-format", "stream-json",
+            "claude",
+            "-p",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
             "--verbose",
             "--include-partial-messages",
         ],
@@ -57,38 +79,47 @@ def main() -> None:
         text=True,
     )
 
+
+def _handle_local_cmd(cmd: str, auto_read: bool) -> tuple[bool, bool]:
+    """Execute a local command. Returns (should_break, new_auto_read)."""
+    if cmd == "exit":
+        return True, auto_read
+    if cmd == "stop":
+        _stop_playback()
+    elif cmd == "toggle":
+        auto_read = not auto_read
+        print(f"auto_read: {'on' if auto_read else 'off'}")
+    return False, auto_read
+
+
+def _make_on_text(buf: list[str]) -> Callable[[str], None]:
+    """Return an on_text callback that appends to buf and writes to stdout."""
+
+    def _on_text(text: str) -> None:
+        buf.append(text)
+        sys.stdout.write(text)
+        sys.stdout.flush()
+
+    return _on_text
+
+
+def main() -> None:
+    """REPL loop: user input → claude stdin (JSON) → read deltas → print + TTS."""
+    config = load_config()
+    auto_read = config.auto_read
+
+    proc = _start_claude()
     assert proc.stdin is not None
     assert proc.stdout is not None
 
-    # Response-complete event — set when reader sees message_stop for current turn
     turn_done = threading.Event()
     response_text: list[str] = []
-
-    def _reader() -> None:
-        """Read claude stdout line-by-line, print text deltas, signal turn completion."""
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            text = parse_stream_event(line)
-            if text is not None:
-                response_text.append(text)
-                sys.stdout.write(text)
-                sys.stdout.flush()
-                continue
-
-            # Check for message_stop (end of turn) or result (final)
-            try:
-                event = json.loads(line)
-            except (json.JSONDecodeError, TypeError):
-                continue
-            etype = event.get("event", {}).get("type") or event.get("type")
-            if etype in ("message_stop", "result"):
-                turn_done.set()
-
-    reader_thread = threading.Thread(target=_reader, daemon=True)
-    reader_thread.start()
-
-    print("cc-voice REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read")
-    print()
+    threading.Thread(
+        target=read_stream_events,
+        args=(proc.stdout, _make_on_text(response_text), turn_done),
+        daemon=True,
+    ).start()
+    print("cc-voice REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read\n")
 
     try:
         while True:
@@ -96,40 +127,25 @@ def main() -> None:
                 user_input = input("user> ")
             except (EOFError, KeyboardInterrupt):
                 break
-
             if not user_input.strip():
                 continue
-
             cmd = parse_local_command(user_input)
-            if cmd == "exit":
-                break
-            if cmd == "stop":
-                _stop_playback()
-                continue
-            if cmd == "toggle":
-                auto_read = not auto_read
-                print(f"auto_read: {'on' if auto_read else 'off'}")
+            if cmd is not None:
+                should_break, auto_read = _handle_local_cmd(cmd, auto_read)
+                if should_break:
+                    break
                 continue
 
-            # Send to claude
             response_text.clear()
             turn_done.clear()
-            msg = format_user_message(user_input) + "\n"
-            proc.stdin.write(msg)
+            proc.stdin.write(format_user_message(user_input) + "\n")
             proc.stdin.flush()
-
-            # Wait for response to complete
             sys.stdout.write("\n")
             turn_done.wait(timeout=120)
             sys.stdout.write("\n\n")
 
-            # Speak full response
-            if auto_read and response_text:
-                full = "".join(response_text).strip()
-                if full:
-                    speak_streaming(
-                        full, voice=config.voice, speed=config.speed, engine=config.engine,
-                    )
+            if auto_read and (full := "".join(response_text).strip()):
+                speak_streaming(full, voice=config.voice, speed=config.speed, engine=config.engine)
     except KeyboardInterrupt:
         pass
     finally:

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -38,16 +38,18 @@ class TestFormatUserMessage:
         assert parsed["message"]["content"] == "hello"
 
     def test_preserves_text(self) -> None:
-        msg = format_user_message("tell me a joke with \"quotes\"")
+        msg = format_user_message('tell me a joke with "quotes"')
         parsed = json.loads(msg)
         assert parsed["message"]["content"] == 'tell me a joke with "quotes"'
 
 
 def _text_delta_line(text: str) -> str:
     """Build a stream-json text_delta event line."""
-    return json.dumps({
-        "event": {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}},
-    })
+    return json.dumps(
+        {
+            "event": {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}},
+        }
+    )
 
 
 def _event_line(etype: str) -> str:
@@ -89,10 +91,12 @@ class TestReadStreamEvents:
         """Non-text, non-stop events do not call on_text or set turn_done."""
         received: list[str] = []
         turn_done = threading.Event()
-        stdout = iter([
-            json.dumps({"event": {"type": "content_block_start"}}),
-            json.dumps({"event": {"type": "content_block_stop"}}),
-        ])
+        stdout = iter(
+            [
+                json.dumps({"event": {"type": "content_block_start"}}),
+                json.dumps({"event": {"type": "content_block_stop"}}),
+            ]
+        )
         read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
         assert received == []
         assert not turn_done.is_set()

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+import threading
 
-from cc_tts.repl import format_user_message, parse_local_command
+from cc_tts.repl import format_user_message, parse_local_command, read_stream_events
 
 
 class TestParseLocalCommand:
@@ -40,3 +41,67 @@ class TestFormatUserMessage:
         msg = format_user_message("tell me a joke with \"quotes\"")
         parsed = json.loads(msg)
         assert parsed["message"]["content"] == 'tell me a joke with "quotes"'
+
+
+def _text_delta_line(text: str) -> str:
+    """Build a stream-json text_delta event line."""
+    return json.dumps({
+        "event": {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}},
+    })
+
+
+def _event_line(etype: str) -> str:
+    """Build a stream-json event line with just a type."""
+    return json.dumps({"event": {"type": etype}})
+
+
+def _result_line() -> str:
+    """Build a stream-json result event line (top-level type)."""
+    return json.dumps({"type": "result"})
+
+
+class TestReadStreamEvents:
+    def test_text_delta_calls_on_text(self) -> None:
+        """text_delta events call on_text with the delta text."""
+        received: list[str] = []
+        turn_done = threading.Event()
+        stdout = iter([_text_delta_line("hello"), _text_delta_line(" world")])
+        read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
+        assert received == ["hello", " world"]
+
+    def test_message_stop_sets_turn_done(self) -> None:
+        """message_stop event sets turn_done."""
+        received: list[str] = []
+        turn_done = threading.Event()
+        stdout = iter([_text_delta_line("hi"), _event_line("message_stop")])
+        read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
+        assert turn_done.is_set()
+
+    def test_result_event_sets_turn_done(self) -> None:
+        """result event (top-level type) sets turn_done."""
+        received: list[str] = []
+        turn_done = threading.Event()
+        stdout = iter([_result_line()])
+        read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
+        assert turn_done.is_set()
+
+    def test_non_text_events_ignored(self) -> None:
+        """Non-text, non-stop events do not call on_text or set turn_done."""
+        received: list[str] = []
+        turn_done = threading.Event()
+        stdout = iter([
+            json.dumps({"event": {"type": "content_block_start"}}),
+            json.dumps({"event": {"type": "content_block_stop"}}),
+        ])
+        read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
+        assert received == []
+        assert not turn_done.is_set()
+
+    def test_invalid_json_skipped(self) -> None:
+        """Invalid JSON lines are silently skipped without raising."""
+        received: list[str] = []
+        turn_done = threading.Event()
+        stdout = iter(["not json at all", "{broken", _text_delta_line("ok")])
+        read_stream_events(stdout, on_text=received.append, turn_done=turn_done)
+        assert received == ["ok"]
+        assert not turn_done.is_set()


### PR DESCRIPTION
## Summary

- Extract `_reader()` closure into top-level `read_stream_events(stdout, on_text, turn_done)` — now independently testable
- Add `_start_claude()`, `_handle_local_cmd()`, `_make_on_text()` module-level helpers to slim down `main()`
- `main()` reduced from ~86 lines to 48 lines (target: < 50)
- Pure refactor — no behavior changes

## TDD

Tests were written first (RED), then the implementation (GREEN):

- `test_text_delta_calls_on_text` — text deltas invoke `on_text` callback
- `test_message_stop_sets_turn_done` — `message_stop` event sets the event
- `test_result_event_sets_turn_done` — top-level `result` type sets the event
- `test_non_text_events_ignored` — other events are silently skipped
- `test_invalid_json_skipped` — malformed lines don't raise

## Test plan

- [x] `uv run pytest tests/test_repl.py` — 13 passed
- [x] `make validate` — lint, type check, 243/244 tests pass (1 pre-existing worktree failure in `test_plugin_config.py`, unrelated)

Closes #55

Generated with Claude <noreply@anthropic.com>