### PR TITLE
chore(rules): add hardening rule — validate, coverage, function length

### DIFF
--- a/.claude/rules/hardening.md
+++ b/.claude/rules/hardening.md
@@ -1,0 +1,9 @@
+# Codebase Hardening
+
+Enforced quality gates for all changes.
+
+- **Validate before commit**: `make validate` must pass (lint + types + tests)
+- **Test coverage**: every new `src/**/*.py` module must have a corresponding `tests/test_*.py`
+- **Function length**: max 50 lines per function — extract if over
+- **No bare exceptions**: always log or re-raise with context
+- **No unused code**: delete dead code, don't comment it out


### PR DESCRIPTION
## Summary

- Add `.claude/rules/hardening.md` for always-on enforcement
- Covers: validate before commit, test coverage for new modules, function length < 50 lines, no bare exceptions, no dead code

## Test plan

- [x] `make validate` passes
- [x] Rule is concise (~10 lines)

Generated with Claude <noreply@anthropic.com>