### PR TITLE
refactor(config): migrate to strict pydantic-settings (#39)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "End-to-end voice plugin for Claude Code — TTS output and STT in
 requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [{ name = "qte77" }]
-dependencies = []
+dependencies = ["pydantic-settings>=2.9.1"]
 
 [project.optional-dependencies]
 piper = ["piper-tts>=1.2.0"]
@@ -36,7 +36,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/cc_tts", "src/cc_stt", "src/cc_vlm"]
+packages = ["src/cc_tts", "src/cc_stt", "src/cc_vlm", "src/cc_voice_common"]
 
 
 # MARK: Linting

--- a/src/cc_stt/config.py
+++ b/src/cc_stt/config.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-import os
-import tomllib
-from dataclasses import dataclass
-from pathlib import Path
+from typing import Any
 
-CONFIG_FILENAMES = [".cc-voice.toml"]
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from cc_voice_common.config import load_toml_section
 
 
-@dataclass
-class STTConfig:
+class STTConfig(BaseSettings):
     """STT plugin configuration."""
+
+    model_config = SettingsConfigDict(env_prefix="CC_STT_", extra="ignore")
 
     engine: str = "auto"
     language: str = "en"
@@ -20,51 +20,20 @@ class STTConfig:
     mic_device: str = "default"
     auto_listen: bool = False
 
-
-def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml."""
-    current = Path.cwd()
-    for directory in [current, *current.parents]:
-        for filename in CONFIG_FILENAMES:
-            candidate = directory / filename
-            if candidate.is_file():
-                return candidate
-    return None
-
-
-def _apply_env_overrides(config: STTConfig) -> None:
-    """Override config fields from CC_STT_* environment variables."""
-    env_map: dict[str, str] = {
-        "CC_STT_ENGINE": "engine",
-        "CC_STT_LANGUAGE": "language",
-        "CC_STT_WAKE_WORD": "wake_word",
-        "CC_STT_MIC_DEVICE": "mic_device",
-        "CC_STT_AUTO_LISTEN": "auto_listen",
-    }
-    type_map: dict[str, type[bool]] = {
-        "auto_listen": bool,
-    }
-    for env_var, attr in env_map.items():
-        value = os.environ.get(env_var)
-        if value is None:
-            continue
-        target_type = type_map.get(attr)
-        if target_type is bool:
-            setattr(config, attr, value.lower() in ("1", "true", "yes"))
-        else:
-            setattr(config, attr, value)
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+        **kwargs: Any,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Priority: env vars > init (TOML values) > defaults."""
+        return (env_settings, init_settings)
 
 
 def load_stt_config() -> STTConfig:
     """Load STT config from [stt] section of .cc-voice.toml with env var overrides."""
-    config = STTConfig()
-    config_file = _find_config_file()
-    if config_file is not None:
-        with config_file.open("rb") as f:
-            data = tomllib.load(f)
-        stt_data = data.get("stt", {})
-        for key, value in stt_data.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-    _apply_env_overrides(config)
-    return config
+    return STTConfig(**load_toml_section("stt"))

--- a/src/cc_tts/config.py
+++ b/src/cc_tts/config.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-import os
-import tomllib
-from dataclasses import dataclass
-from pathlib import Path
+from typing import Any
 
-CONFIG_FILENAMES = [".cc-voice.toml"]
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from cc_voice_common.config import load_toml_section
 
 
-@dataclass
-class TTSConfig:
+class TTSConfig(BaseSettings):
     """TTS plugin configuration."""
+
+    model_config = SettingsConfigDict(env_prefix="CC_TTS_", extra="ignore")
 
     engine: str = "auto"
     voice: str = "en_US-amy-medium"
@@ -21,56 +21,20 @@ class TTSConfig:
     max_chars: int = 2000
     player: str = "auto"
 
-
-def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml."""
-    current = Path.cwd()
-    for directory in [current, *current.parents]:
-        for filename in CONFIG_FILENAMES:
-            candidate = directory / filename
-            if candidate.is_file():
-                return candidate
-    return None
-
-
-def _apply_env_overrides(config: TTSConfig) -> None:
-    """Override config fields from CC_TTS_* environment variables."""
-    env_map: dict[str, str] = {
-        "CC_TTS_ENGINE": "engine",
-        "CC_TTS_VOICE": "voice",
-        "CC_TTS_SPEED": "speed",
-        "CC_TTS_AUTO_READ": "auto_read",
-        "CC_TTS_MAX_CHARS": "max_chars",
-        "CC_TTS_PLAYER": "player",
-    }
-    type_map: dict[str, type[int] | type[float] | type[bool] | type[str]] = {
-        "speed": float,
-        "max_chars": int,
-        "auto_read": bool,
-    }
-    for env_var, attr in env_map.items():
-        value = os.environ.get(env_var)
-        if value is None:
-            continue
-        target_type = type_map.get(attr)
-        if target_type is bool:
-            setattr(config, attr, value.lower() in ("1", "true", "yes"))
-        elif target_type is not None:
-            setattr(config, attr, target_type(value))
-        else:
-            setattr(config, attr, value)
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+        **kwargs: Any,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Priority: env vars > init (TOML values) > defaults."""
+        return (env_settings, init_settings)
 
 
 def load_config() -> TTSConfig:
     """Load config from .cc-voice.toml [tts] section with env var overrides."""
-    config = TTSConfig()
-    config_file = _find_config_file()
-    if config_file is not None:
-        with config_file.open("rb") as f:
-            data = tomllib.load(f)
-        tts_data = data.get("tts", {})
-        for key, value in tts_data.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-    _apply_env_overrides(config)
-    return config
+    return TTSConfig(**load_toml_section("tts"))

--- a/src/cc_tts/speak.py
+++ b/src/cc_tts/speak.py
@@ -95,9 +95,9 @@ def synthesize_and_play(text: str, config: TTSConfig | None = None) -> None:
 
 def _toggle_auto_read() -> None:
     """Toggle auto_read in .cc-voice.toml [tts] section."""
-    from cc_tts.config import _find_config_file  # pyright: ignore[reportPrivateUsage]
+    from cc_voice_common.config import find_config_file
 
-    config_path = _find_config_file()
+    config_path = find_config_file()
     if config_path is None:
         print("No .cc-voice.toml found — create one first", file=sys.stderr)
         sys.exit(1)

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -1,22 +1,18 @@
-"""Configuration loading from .cc-voice.toml [vlm] section and environment variables.
-
-Mirrors cc_stt.config layout — same file-walk search, same env override
-mechanism, same dataclass defaults pattern.
-"""
+"""Configuration loading from .cc-voice.toml [vlm] section and environment variables."""
 
 from __future__ import annotations
 
-import os
-import tomllib
-from dataclasses import dataclass
-from pathlib import Path
+from typing import Any
 
-CONFIG_FILENAMES = [".cc-voice.toml"]
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from cc_voice_common.config import load_toml_section
 
 
-@dataclass
-class VLMConfig:
+class VLMConfig(BaseSettings):
     """VLM plugin configuration for the llama-cpp-python in-process engine."""
+
+    model_config = SettingsConfigDict(env_prefix="CC_VLM_", extra="ignore")
 
     engine: str = "auto"
     model_path: str = ""
@@ -30,65 +26,20 @@ class VLMConfig:
     template: str = "generic"
     cache_size: int = 32
 
-
-def _find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml."""
-    current = Path.cwd()
-    for directory in [current, *current.parents]:
-        for filename in CONFIG_FILENAMES:
-            candidate = directory / filename
-            if candidate.is_file():
-                return candidate
-    return None
-
-
-def _apply_env_overrides(config: VLMConfig) -> None:
-    """Override config fields from CC_VLM_* environment variables."""
-    env_map: dict[str, str] = {
-        "CC_VLM_ENGINE": "engine",
-        "CC_VLM_MODEL_PATH": "model_path",
-        "CC_VLM_MMPROJ_PATH": "mmproj_path",
-        "CC_VLM_HANDLER_NAME": "handler_name",
-        "CC_VLM_N_CTX": "n_ctx",
-        "CC_VLM_N_GPU_LAYERS": "n_gpu_layers",
-        "CC_VLM_MAX_TOKENS": "max_tokens",
-        "CC_VLM_MAX_DIMENSION": "max_dimension",
-        "CC_VLM_JPEG_QUALITY": "jpeg_quality",
-        "CC_VLM_TEMPLATE": "template",
-        "CC_VLM_CACHE_SIZE": "cache_size",
-    }
-    int_fields = {
-        "n_ctx",
-        "n_gpu_layers",
-        "max_tokens",
-        "max_dimension",
-        "jpeg_quality",
-        "cache_size",
-    }
-    for env_var, attr in env_map.items():
-        value = os.environ.get(env_var)
-        if value is None:
-            continue
-        if attr in int_fields:
-            try:
-                setattr(config, attr, int(value))
-            except ValueError:
-                # Reason: bad env input falls back to current default rather than crash
-                continue
-        else:
-            setattr(config, attr, value)
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+        **kwargs: Any,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Priority: env vars > init (TOML values) > defaults."""
+        return (env_settings, init_settings)
 
 
 def load_vlm_config() -> VLMConfig:
     """Load VLM config from [vlm] section of .cc-voice.toml with env var overrides."""
-    config = VLMConfig()
-    config_file = _find_config_file()
-    if config_file is not None:
-        with config_file.open("rb") as f:
-            data = tomllib.load(f)
-        vlm_data = data.get("vlm", {})
-        for key, value in vlm_data.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-    _apply_env_overrides(config)
-    return config
+    return VLMConfig(**load_toml_section("vlm"))

--- a/src/cc_voice_common/__init__.py
+++ b/src/cc_voice_common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for cc-voice plugins."""

--- a/src/cc_voice_common/config.py
+++ b/src/cc_voice_common/config.py
@@ -1,0 +1,30 @@
+"""Shared config utilities — TOML discovery and section loading for cc-voice plugins."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+CONFIG_FILENAMES = [".cc-voice.toml"]
+
+
+def find_config_file() -> Path | None:
+    """Walk up from cwd to find .cc-voice.toml."""
+    current = Path.cwd()
+    for directory in [current, *current.parents]:
+        for filename in CONFIG_FILENAMES:
+            candidate = directory / filename
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def load_toml_section(section: str) -> dict[str, Any]:
+    """Load a section from .cc-voice.toml, returning {} if not found."""
+    config_file = find_config_file()
+    if config_file is None:
+        return {}
+    with config_file.open("rb") as f:
+        data = tomllib.load(f)
+    return dict(data.get(section, {}))

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -1,4 +1,4 @@
-"""Tests for cc_vlm.config — VLMConfig dataclass + TOML + env overrides."""
+"""Tests for cc_vlm.config — VLMConfig BaseSettings + TOML + env overrides."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from cc_vlm.config import VLMConfig, _apply_env_overrides, load_vlm_config
+from cc_vlm.config import VLMConfig, load_vlm_config
 
 
 class TestVLMConfigDefaults:
@@ -50,7 +50,6 @@ class TestEnvOverrides:
         monkeypatch.setenv("CC_VLM_HANDLER_NAME", "llava15")
         monkeypatch.setenv("CC_VLM_TEMPLATE", "terminal")
         config = VLMConfig()
-        _apply_env_overrides(config)
         assert config.engine == "llamacpp"
         assert config.model_path == "/tmp/qwen.gguf"
         assert config.mmproj_path == "/tmp/qwen-mmproj.gguf"
@@ -65,7 +64,6 @@ class TestEnvOverrides:
         monkeypatch.setenv("CC_VLM_JPEG_QUALITY", "75")
         monkeypatch.setenv("CC_VLM_CACHE_SIZE", "64")
         config = VLMConfig()
-        _apply_env_overrides(config)
         assert config.n_ctx == 8192
         assert config.n_gpu_layers == -1
         assert config.max_tokens == 512
@@ -73,15 +71,13 @@ class TestEnvOverrides:
         assert config.jpeg_quality == 75
         assert config.cache_size == 64
 
-    def test_invalid_int_env_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_int_env_raises_validation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CC_VLM_MAX_DIMENSION", "not-a-number")
-        config = VLMConfig()
-        _apply_env_overrides(config)
-        assert config.max_dimension == 768  # unchanged
+        with pytest.raises(Exception):  # noqa: B017
+            VLMConfig()
 
     def test_env_missing_leaves_defaults(self) -> None:
         config = VLMConfig()
-        _apply_env_overrides(config)
         assert config.engine == "auto"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,6 +273,9 @@ wheels = [
 name = "cc-voice"
 version = "0.5.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic-settings" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -319,6 +322,7 @@ requires-dist = [
     { name = "mss", marker = "extra == 'see'", specifier = ">=9.0.0" },
     { name = "pillow", marker = "extra == 'see'", specifier = ">=10.0.0" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.2.0" },
+    { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

- Add `pydantic-settings` dependency and shared `cc_voice_common.config` module with `find_config_file()` + `load_toml_section()`
- Replace 3 dataclass + manual env-override config modules (TTS, STT, VLM) with `BaseSettings` subclasses
- Net reduction: 240 → 155 LOC (-85 lines) by eliminating duplicated `_find_config_file()`, `_apply_env_overrides()`, and `load_*()` boilerplate
- Invalid env values now raise `ValidationError` instead of silently falling back (strict pydantic per #39)
- Preserves: env var names (`CC_TTS_*` etc.), `.cc-voice.toml` format, `load_config()` API, priority order (env > TOML > defaults)

Closes #39

## Test plan

- [x] All 23 config tests pass (defaults, TOML loading, env overrides, unknown keys ignored)
- [x] Full suite: 240/240 non-optional tests pass, 0 regressions
- [x] Lint passes on all changed files
- [ ] Manual: verify `cc-tts --toggle` still toggles `auto_read` in `.cc-voice.toml`

Generated with Claude <noreply@anthropic.com>