### PR TITLE
fix(gha): bump workflow creates PR instead of pushing to main

### DIFF
--- a/.github/scripts/create_pr.sh
+++ b/.github/scripts/create_pr.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Create a PR for a version bump.
+# Usage: create_pr.sh <base> <head> <title_suffix> <old_version> <new_version>
+set -euo pipefail
+
+if [[ $# -lt 5 ]]; then
+  echo "Usage: $0 <base> <head> <title_suffix> <old_version> <new_version>" >&2
+  exit 1
+fi
+
+base="$1"
+head="$2"
+title_suffix="$3"
+old_version="$4"
+new_version="$5"
+
+pr_title="chore: bump version $old_version → $new_version $title_suffix"
+pr_body="PR automatically created to bump from \`$old_version\` to \`$new_version\` on \`$head\`. Tag \`v$new_version\` will be created and must be deleted manually if PR is closed without merge."
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "gh pr create --base $base --head $head --title \"$pr_title\" --body \"$pr_body\""
+  exit 0
+fi
+
+gh pr create \
+  --base "$base" \
+  --head "$head" \
+  --title "$pr_title" \
+  --body "$pr_body"

--- a/.github/scripts/delete_branch_pr_tag.sh
+++ b/.github/scripts/delete_branch_pr_tag.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Cleanup on bump failure: delete tag, close PR, delete branch.
+# Usage: delete_branch_pr_tag.sh <repo> <branch> <version>
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <repo> <branch> <version>" >&2
+  exit 1
+fi
+
+repo="$1"
+branch="$2"
+tag_to_delete="v$3"
+branch_del_api="repos/$repo/git/refs/heads/$branch"
+close_msg="Closing PR '$branch' to rollback after failure"
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "git tag -d $tag_to_delete"
+  echo "gh pr close $branch --comment \"$close_msg\""
+  echo "gh api $branch_del_api -X DELETE"
+  echo "Cleanup: tag=$tag_to_delete branch=$branch"
+  exit 0
+fi
+
+echo "Deleting tag $tag_to_delete"
+git tag -d "$tag_to_delete" 2>/dev/null || true
+
+echo "Closing PR for $branch"
+gh pr close "$branch" --comment "$close_msg" 2>/dev/null || true
+
+echo "Deleting branch $branch"
+gh api "$branch_del_api" -X DELETE 2>/dev/null && \
+  echo "Branch deleted." || echo "Branch deletion failed (may not exist)."

--- a/.github/workflows/bump-my-version.yaml
+++ b/.github/workflows/bump-my-version.yaml
@@ -12,8 +12,14 @@ on:
           - minor
           - major
 
+env:
+  BRANCH_NEW: "bump-${{ github.run_number }}-${{ github.ref_name }}"
+  SKIP_PR_HINT: "[skip ci bump]"
+  SCRIPT_PATH: ".github/scripts"
+
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -21,14 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+
+      - name: Set git config and create branch
+        run: |
+          git config user.email "bumped@qte77.gha"
+          git config user.name "bump-my-version"
+          git checkout -b "${{ env.BRANCH_NEW }}"
 
       - name: Bump version
+        id: bump
         uses: callowayproject/bump-my-version@0.29.0
+        env:
+          BUMPVERSION_TAG: "true"
         with:
           args: ${{ inputs.bump_type }}
+          branch: ${{ env.BRANCH_NEW }}
+
+      - name: Create PR
+        if: steps.bump.outputs.bumped == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          src="${{ env.SCRIPT_PATH }}/create_pr.sh"
+          chmod +x "$src"
+          $src "${{ github.ref_name }}" "${{ env.BRANCH_NEW }}" "${{ env.SKIP_PR_HINT }}" "${{ steps.bump.outputs.previous-version }}" "${{ steps.bump.outputs.current-version }}"
 
-      - name: Push changes
-        run: git push --follow-tags
+      - name: Cleanup on failure
+        if: failure() || cancelled()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          src="${{ env.SCRIPT_PATH }}/delete_branch_pr_tag.sh"
+          chmod +x "$src"
+          $src "${{ github.repository }}" "${{ env.BRANCH_NEW }}" "${{ steps.bump.outputs.current-version }}"

--- a/tests/test_bump_scripts.bats
+++ b/tests/test_bump_scripts.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/create_pr.sh and delete_branch_pr_tag.sh
+
+SCRIPT_DIR=".github/scripts"
+
+# --- File existence and permissions ---
+
+@test "create_pr.sh exists" {
+  [[ -f "$SCRIPT_DIR/create_pr.sh" ]]
+}
+
+@test "delete_branch_pr_tag.sh exists" {
+  [[ -f "$SCRIPT_DIR/delete_branch_pr_tag.sh" ]]
+}
+
+@test "create_pr.sh is executable" {
+  [[ -x "$SCRIPT_DIR/create_pr.sh" ]]
+}
+
+@test "delete_branch_pr_tag.sh is executable" {
+  [[ -x "$SCRIPT_DIR/delete_branch_pr_tag.sh" ]]
+}
+
+# --- create_pr.sh argument validation ---
+
+@test "create_pr.sh fails with no args" {
+  run bash "$SCRIPT_DIR/create_pr.sh"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "create_pr.sh fails with 1 arg" {
+  run bash "$SCRIPT_DIR/create_pr.sh" main
+  [[ "$status" -ne 0 ]]
+}
+
+@test "create_pr.sh fails with 4 args (needs 5)" {
+  run bash "$SCRIPT_DIR/create_pr.sh" main bump-1 suffix 0.5.0
+  [[ "$status" -ne 0 ]]
+}
+
+# --- create_pr.sh dry-run ---
+
+@test "create_pr.sh dry-run shows gh pr create" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/create_pr.sh" main bump-42-main "[skip ci]" 0.5.0 0.6.0
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"gh pr create"* ]]
+}
+
+@test "create_pr.sh dry-run uses correct base branch" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/create_pr.sh" main bump-42-main "[skip ci]" 0.5.0 0.6.0
+  [[ "$output" == *"--base main"* ]]
+}
+
+@test "create_pr.sh dry-run uses correct head branch" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/create_pr.sh" main bump-42-main "[skip ci]" 0.5.0 0.6.0
+  [[ "$output" == *"--head bump-42-main"* ]]
+}
+
+@test "create_pr.sh dry-run body contains version transition" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/create_pr.sh" main bump-42-main "[skip ci]" 0.5.0 0.6.0
+  [[ "$output" == *"0.5.0"* ]]
+  [[ "$output" == *"0.6.0"* ]]
+}
+
+# --- delete_branch_pr_tag.sh argument validation ---
+
+@test "delete_branch_pr_tag.sh fails with no args" {
+  run bash "$SCRIPT_DIR/delete_branch_pr_tag.sh"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "delete_branch_pr_tag.sh fails with 2 args (needs 3)" {
+  run bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42
+  [[ "$status" -ne 0 ]]
+}
+
+# --- delete_branch_pr_tag.sh dry-run ---
+
+@test "delete_branch_pr_tag.sh dry-run references correct tag" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42-main 0.6.0
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"v0.6.0"* ]]
+}
+
+@test "delete_branch_pr_tag.sh dry-run references correct branch" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42-main 0.6.0
+  [[ "$output" == *"bump-42-main"* ]]
+}
+
+@test "delete_branch_pr_tag.sh dry-run includes git tag delete" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42-main 0.6.0
+  [[ "$output" == *"git tag -d"* ]]
+}
+
+@test "delete_branch_pr_tag.sh dry-run includes pr close" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42-main 0.6.0
+  [[ "$output" == *"gh pr close"* ]]
+}
+
+@test "delete_branch_pr_tag.sh dry-run includes branch API delete" {
+  run env DRY_RUN=1 bash "$SCRIPT_DIR/delete_branch_pr_tag.sh" owner/repo bump-42-main 0.6.0
+  [[ "$output" == *"gh api"* ]]
+}
+
+# --- Workflow YAML structure ---
+
+@test "workflow has workflow_dispatch trigger" {
+  grep -q "workflow_dispatch" .github/workflows/bump-my-version.yaml
+}
+
+@test "workflow has pull-requests write permission" {
+  grep -q "pull-requests: write" .github/workflows/bump-my-version.yaml
+}
+
+@test "workflow references create_pr.sh" {
+  grep -q "create_pr.sh" .github/workflows/bump-my-version.yaml
+}
+
+@test "workflow references delete_branch_pr_tag.sh" {
+  grep -q "delete_branch_pr_tag.sh" .github/workflows/bump-my-version.yaml
+}
+
+@test "workflow creates ephemeral bump branch" {
+  grep -q 'BRANCH_NEW.*bump-' .github/workflows/bump-my-version.yaml
+}
+
+@test "workflow does NOT push directly to main" {
+  ! grep -q "git push --follow-tags" .github/workflows/bump-my-version.yaml
+}


### PR DESCRIPTION
## Summary

- Replace direct-push bump workflow (blocked by branch protection) with PR-based flow
- Add `.github/scripts/create_pr.sh` — creates PR from ephemeral bump branch
- Add `.github/scripts/delete_branch_pr_tag.sh` — cleans up on failure (tag, PR, branch)
- Pattern ported from Agents-eval repo
- 24 BATS tests covering script args, dry-run output, and workflow YAML structure

## Test plan

- [x] 24/24 BATS tests pass (`bats tests/test_bump_scripts.bats`)
- [ ] Trigger `Bump Version` workflow dispatch with `patch` — verify PR created (not direct push)

Generated with Claude <noreply@anthropic.com>