### PR TITLE
chore: enable gha-dev plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,7 +69,8 @@
     "security-audit@qte77-claude-code-plugins": true,
     "makefile-core@qte77-claude-code-plugins": true,
     "docs-generator@qte77-claude-code-plugins": true,
-    "readme-generator@qte77-claude-code-plugins": true
+    "readme-generator@qte77-claude-code-plugins": true,
+    "gha-dev@qte77-claude-code-plugins": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-plugins": {

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "cc-voice"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Summary

- Enable `gha-dev@qte77-claude-code-plugins` in `.claude/settings.json` for BATS testing and GHA skill access
- Update `uv.lock` (pydantic-settings dep from #66)

## Test plan

- [x] No code changes — config only

Generated with Claude <noreply@anthropic.com>