### PR TITLE
fix(plugins): correct marketplace name to qte77-claude-code-utils

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,20 +60,20 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "tdd-core@qte77-claude-code-plugins": true,
-    "python-dev@qte77-claude-code-plugins": true,
-    "commit-helper@qte77-claude-code-plugins": true,
-    "codebase-tools@qte77-claude-code-plugins": true,
-    "cc-meta@qte77-claude-code-plugins": true,
+    "tdd-core@qte77-claude-code-utils": true,
+    "python-dev@qte77-claude-code-utils": true,
+    "commit-helper@qte77-claude-code-utils": true,
+    "codebase-tools@qte77-claude-code-utils": true,
+    "cc-meta@qte77-claude-code-utils": true,
     "cc-voice@cc-voice": true,
-    "security-audit@qte77-claude-code-plugins": true,
-    "makefile-core@qte77-claude-code-plugins": true,
-    "docs-generator@qte77-claude-code-plugins": true,
-    "readme-generator@qte77-claude-code-plugins": true,
-    "gha-dev@qte77-claude-code-plugins": true
+    "security-audit@qte77-claude-code-utils": true,
+    "makefile-core@qte77-claude-code-utils": true,
+    "docs-generator@qte77-claude-code-utils": true,
+    "readme-generator@qte77-claude-code-utils": true,
+    "gha-dev@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-plugins": {
+    "qte77-claude-code-utils": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-plugins"


### PR DESCRIPTION
## Summary
- Rename marketplace key `qte77-claude-code-plugins` → `qte77-claude-code-utils` in `.claude/settings.json`
- Aligns with marketplace self-identifier at `qte77/claude-code-plugins`; `source.repo` unchanged

## Why
The marketplace at `qte77/claude-code-plugins` self-identifies as `qte77-claude-code-utils`. The mismatched key caused `/reload-plugins` to fail with `Plugin not found in marketplace` for every entry.

## Test plan
- [ ] `/reload-plugins` reports 0 errors
- [ ] `/doctor` shows no marketplace mismatches

Mirrors qte77/polyforge-orchestrator#60.

Generated with Claude <noreply@anthropic.com>