### PR TITLE
ci(lint): adopt centralized markdown + link checking

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -1,0 +1,17 @@
+---
+name: Lint MD and Links
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@3b1579152e930a53b13d987a9c2344f79e3007d5  # 2026-04-27
+...


### PR DESCRIPTION
## Summary
Adopt the centralized lint pipeline (markdownlint + lychee) from `qte77/.github`.

This adds **CI-blocking** markdown linting and link checking on PRs to main. The existing `links-fail-fast.yaml` (scheduled link monitoring + issue creation on failure) is **kept** — it serves a different purpose (background monitoring, not PR gating).

`uses:` is SHA-pinned to `qte77/.github` main of 2026-04-27 per qte77 internal convention.

## Override

Commit a `.markdownlint.jsonc` or `lychee.toml` at repo root to override the shared config from `qte77/.github`.

Generated with Claude <noreply@anthropic.com>