### PR TITLE
docs(roadmap): fix drift — v0.5.0/v0.6.0 shipped, drop closed issues

### DIFF
--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -1,9 +1,9 @@
-# cc-voice v0.5.x roadmap
+# cc-voice roadmap (v0.5.x → v0.6.x)
 
-Living document for tracked and deferred work on the 0.5.x development line.
-**Actionable items are filed as GitHub issues** with the `enhancement` label;
-this file captures the **deferred** items and **rejected** directions that
-don't belong in the issue tracker.
+Living document for tracked and deferred work on the 0.5.x and 0.6.x
+development lines. **Actionable items are filed as GitHub issues** with the
+`enhancement` label; this file captures the **deferred** items and
+**rejected** directions that don't belong in the issue tracker.
 
 ## Source of truth
 
@@ -17,18 +17,18 @@ don't belong in the issue tracker.
 | Version | PRs | Highlights |
 |---|---|---|
 | **v0.4.0** (tagged 2026-04-11) | #14, #17, #18, #19, #20, #21, #22, #23, #24, #25 | `/listen` pipeline, ADR-0003 (VLM screen-sharing), build + typing cleanup, dep-bump sweep, repo hygiene |
-| **v0.5.0** (unreleased — tracked in #34) | #26, #28 | `/see` module (`cc_vlm` with `llama-cpp-python`), `setup_user` Makefile target |
+| **v0.5.0** (tagged 2026-04-11) | #26, #28, #36 | `/see` module (`cc_vlm` with `llama-cpp-python`), `setup_user` Makefile target |
+| **v0.6.0** (tagged 2026-04-23) | #29, #33, #39, #56, #70, #71, #72, #73 | listen token optimization, streaming sentence TTS in REPL, pydantic config migration, ADR-0001 refresh, CONTRIBUTING.md, bump-helper scripts |
 
 ## Tracked in GitHub issues (actionable)
 
 Filed alongside this roadmap — see each issue for full scope + acceptance criteria:
 
-- **#29** — `feat(listen): token optimization — filler strip + local intent match + word cap`
 - **#30** — `feat(tts): Kokoro voice blending via embedding math`
 - **#31** — `feat(stt): Whisper engine via faster-whisper (enables domain fine-tunes)`
 - **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr (multilingual, CC-BY-4.0)`
-- **#33** — `docs(adr): update ADR-0001 — Qwen3-VL-2B, LFM2-VL-3B, Tier-2-first decision`
-- **#34** — `chore(release): tag v0.5.0`
+- **#45** — `bug(plugin): stale plugin cache not refreshed from local directory source`
+- **#60** — `docs: restructure doc hierarchy — slim ADRs, add architecture.md, UserStory.md`
 
 When one of these lands, link back to this file if scope expanded or contracted.
 
@@ -62,9 +62,9 @@ filing noise in the tracker.
 
 - **README + docs restructure** — slim README ≤60 lines, create
   `docs/config.md` as the single source of truth for `.cc-voice.toml`,
-  add `docs/engines.md`, `docs/architecture.md`, `CONTRIBUTING.md`,
-  dedupe SKILL.md config sections. Large scope, good hygiene, not blocking
-  any feature work.
+  add `docs/engines.md`, dedupe SKILL.md config sections. Partly tracked
+  in **#60** (doc hierarchy restructure); `docs/architecture.md` and
+  `CONTRIBUTING.md` already shipped in v0.6.0.
 - **ADR-0002 "full-duplex voice" future direction** — PersonaPlex / Moshi
   architecture note. Historical record; cc-voice stays half-duplex with
   pluggable engines by design. Write when someone asks about the


### PR DESCRIPTION
## Summary

Sync `docs/roadmap/v0.5.x.md` with reality. The roadmap had drifted in three places:

- **v0.5.0** row said *"unreleased — tracked in #34"* but #34 closed 2026-04-11 and v0.5.0 was tagged the same day.
- **Tracked** section still listed #29 (closed 2026-04-22), #33 (closed 2026-04-21), and #34 — all shipped in v0.5.0/v0.6.0.
- **Deferred docs** item said `docs/architecture.md` and `CONTRIBUTING.md` were missing; both shipped in v0.6.0 (via #39, #56).

## Changes

- Reframe title to cover v0.5.x → v0.6.x (file name kept to preserve external link from `AGENTS.md`).
- Add **v0.6.0** row to *Recently shipped* (PRs #29, #33, #39, #56, #70, #71, #72, #73).
- Update v0.5.0 row from *"unreleased"* → *"tagged 2026-04-11"*; include release PR #36.
- Drop #29, #33, #34 from *Tracked in GitHub issues*; they're done.
- Add open #45 (plugin cache bug) and #60 (doc hierarchy) which were filed after the roadmap was last touched.
- Trim the *README + docs restructure* deferred item to reflect that `architecture.md` and `CONTRIBUTING.md` already exist; point at #60 for the remaining work.

## Test plan

- [x] `git diff` — only the roadmap file is touched (12 insertions / 12 deletions)
- [x] All referenced issues exist; closed-vs-open status verified via `gh issue view`
- [x] All referenced PRs exist in `git log` and `CHANGELOG.md`
- [x] No code, hooks, or plugin manifests changed → no version bump needed

Generated with Claude <noreply@anthropic.com>