### PR TITLE
chore: gitignore phantom .mcp.json and .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 /.zshrc
 /.gitconfig
 /.gitmodules
+/.mcp.json
 /.ripgreprc
 
 # created as empty files, not dirs — bypass trailing-slash gitignore patterns
@@ -65,6 +66,7 @@ dist/
 
 # Claude Code local overrides
 .claude/settings.local.json
+.env
 
 # Auto-memory seed (created by session hooks, not project code)
 MEMORY.md


### PR DESCRIPTION
## Summary

Two `.gitignore` additions to silence noise from `git status` during local sandboxed runs:

- **`/.mcp.json`** — added to the *shell-dotfiles* phantom block (next to `/.gitconfig`). Same root cause as the entries already in that block: bwrap bind-mounts resolve `~/.mcp.json` against cwd instead of `\$HOME`, leaking a 0-byte character-special device into the repo root. The header comment in `.gitignore` already cites upstream issues #17087, #17374, #17727.
- **`.env`** — added to the *Claude Code local overrides* block (next to `.claude/settings.local.json`). This one is a real file, not a phantom — used for per-machine secrets — and should not appear as untracked.

Verified locally: a 0-byte `crw-rw-rw-` `.mcp.json` (uid/gid `nobody`) was the artifact prompting this — confirmed via `stat`. Real config still lives in `\$HOME`.

## Test plan

- [x] `git diff` — only `.gitignore` is touched (+2 lines, 0 deletions)
- [x] Both entries placed in the correct existing block (no new sections added)
- [x] After commit, `git status` no longer reports `.env` or `.mcp.json`
- [x] No code or plugin manifests changed → no version bump needed

Generated with Claude <noreply@anthropic.com>