### PR TITLE
docs: dedupe config + add UserStory + slim README/SKILL.md (closes #60)

### DIFF
--- a/.cc-voice.example.toml
+++ b/.cc-voice.example.toml
@@ -1,5 +1,7 @@
 # CC-Voice configuration
 # Copy to .cc-voice.toml and adjust as needed.
+#
+# Handler-name values for [vlm] are listed in docs/architecture.md.
 
 # TTS settings (env overrides: CC_TTS_ENGINE, CC_TTS_VOICE, CC_TTS_SPEED,
 # CC_TTS_AUTO_READ, CC_TTS_MAX_CHARS, CC_TTS_PLAYER)
@@ -11,10 +13,31 @@ max_chars = 2000             # Truncate input text beyond this limit
 player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
 
 # STT settings (env overrides: CC_STT_ENGINE, CC_STT_LANGUAGE,
-# CC_STT_WAKE_WORD, CC_STT_MIC_DEVICE, CC_STT_AUTO_LISTEN)
+# CC_STT_WAKE_WORD, CC_STT_MIC_DEVICE, CC_STT_AUTO_LISTEN,
+# CC_STT_STRIP_FILLERS, CC_STT_INTENT_MATCH, CC_STT_MAX_WORDS)
 [stt]
 engine = "auto"              # "moonshine" | "vosk" | "auto"
 language = "en"
 wake_word = "hey_claude"
 mic_device = "default"
 auto_listen = false          # Start listening on session start
+strip_fillers = true         # Remove "um", "uh", "like" before sending to LLM
+intent_match = true          # Match common commands locally (skip LLM)
+max_words = 200              # Hard word cap on transcriptions
+
+# VLM settings (env overrides: CC_VLM_ENGINE, CC_VLM_MODEL_PATH,
+# CC_VLM_MMPROJ_PATH, CC_VLM_HANDLER_NAME, CC_VLM_N_CTX,
+# CC_VLM_N_GPU_LAYERS, CC_VLM_MAX_TOKENS, CC_VLM_MAX_DIMENSION,
+# CC_VLM_JPEG_QUALITY, CC_VLM_TEMPLATE, CC_VLM_CACHE_SIZE)
+[vlm]
+engine = "auto"              # "auto" | "llamacpp"
+model_path = ""              # Absolute path to .gguf vision model
+mmproj_path = ""             # Absolute path to mmproj (CLIP projector) .gguf
+handler_name = "qwen2.5vl"   # Chat handler — see docs/architecture.md
+n_ctx = 4096                 # Context window
+n_gpu_layers = 0             # 0 = CPU only, -1 = all layers to GPU
+max_tokens = 256             # Max VLM response tokens
+max_dimension = 768          # Resize longest edge before VLM (tokens ∝ dimension²)
+jpeg_quality = 85
+template = "generic"         # Default template if --template not passed
+cache_size = 32              # Per-invocation LRU entries

--- a/.cc-voice.example.toml
+++ b/.cc-voice.example.toml
@@ -5,6 +5,7 @@
 
 # TTS settings (env overrides: CC_TTS_ENGINE, CC_TTS_VOICE, CC_TTS_SPEED,
 # CC_TTS_AUTO_READ, CC_TTS_MAX_CHARS, CC_TTS_PLAYER)
+[tts]
 engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto"
 voice = "en_US-amy-medium"   # Engine-specific voice name
 speed = 1.0                  # Playback speed multiplier

--- a/README.md
+++ b/README.md
@@ -9,25 +9,13 @@
 [![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)
 [![Link Checker](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml)
 
-End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk.
+End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk, VLM ingests the screen and feeds it as text into Claude's context for Claude to act on.
 
 ## Features
 
-### TTS (text-to-speech)
-
-- **Live TTS via PTY proxy** — wraps interactive Claude Code with real-time sentence-chunked speech (`cc-tts-wrap claude`)
-- **Batch TTS via Stop hook** — speaks full responses after completion (fallback for non-PTY environments)
-- **Smart content filter** — strips ANSI escapes, code blocks, tool output, spinners; speaks only prose
-- **Multi-engine TTS** — Kokoro (best), Piper (neural), espeak-ng (zero-config), auto-detection
-- **On-demand `/speak` skill** — speak specific text or toggle auto-read mode
-
-### STT (speech-to-text)
-
-- **STTEngine protocol** — Moonshine (27M params, ~400ms) and Vosk (50MB) with auto-detection
-- **Mic capture** — sounddevice streaming with `NoMicrophoneError` graceful degradation
-- **Utterance buffer** — energy-based VAD with silence boundary detection and max duration timeout
-- **PTY injection** — transcribed text written to master PTY fd for child process stdin
-- **On-demand `/listen` skill** — voice input and offline transcription (planned)
+- **TTS** — `/speak` skill, Stop-hook auto-read, multi-engine (Kokoro / Piper / espeak-ng / edge-tts)
+- **STT** — `/listen` skill, Moonshine/Vosk auto-detect, mic capture with VAD, PTY injection
+- **VLM** — `/see` skill, in-process Qwen2.5-VL via llama-cpp-python, screen → text into Claude's context (~120 tokens/call vs ~1,600 raw vision)
 
 ## Audio Examples
 
@@ -42,142 +30,42 @@ Session summary generated with three engines for comparison:
 ## Quick Start
 
 ```bash
-make setup_dev    # install package + dev deps
-make setup_tts    # install espeak-ng + mpv (robotic, zero-config)
-make setup_piper  # install Piper (neural, good quality)
-make setup_kokoro # install Kokoro (best local quality)
+make setup_dev      # install package + dev deps
+make setup_tts      # install espeak-ng + mpv (zero-config baseline)
+make setup_piper    # install Piper (neural)
+make setup_kokoro   # install Kokoro (best local)
 
-# Live TTS (PTY wrapper — real-time)
-cc-tts-wrap claude
-
-# On-demand TTS (CLI)
-cc-tts "Hello from Claude Code"
-
-# Batch auto-read (Stop hook — set in .cc-voice.toml [tts])
-# auto_read = true
+cc-tts-wrap claude  # live PTY-wrapped TTS
+cc-tts "Hello"      # one-shot CLI
 ```
 
 ## Configuration
 
-Create `.cc-voice.toml` in project root:
+Copy [`.cc-voice.example.toml`](.cc-voice.example.toml) to `.cc-voice.toml` and edit. All TTS, STT, and VLM fields plus `CC_*` env-var overrides are documented inline.
 
-```toml
-engine = "auto"              # "espeak" | "piper" | "kokoro" | "auto"
-voice = "en_US-amy-medium"   # engine-specific voice name
-speed = 1.0
-auto_read = false            # enable Stop hook auto-read
-max_chars = 2000
-player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
-
-[stt]
-engine = "auto"              # "moonshine" | "vosk" | "auto"
-language = "en"
-wake_word = "hey_claude"
-mic_device = "default"
-auto_listen = false
-```
-
-TTS env overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`, `CC_TTS_MAX_CHARS`, `CC_TTS_PLAYER`.
-
-STT env overrides: `CC_STT_ENGINE`, `CC_STT_LANGUAGE`, `CC_STT_WAKE_WORD`, `CC_STT_MIC_DEVICE`, `CC_STT_AUTO_LISTEN`.
-
-## TTS delivery modes
-
-Three paths for getting Claude's text to TTS, each with trade-offs:
-
-| Mode | Interactive? | Ink UI? | Real streaming? | Brittleness | Entry point |
-|------|-------------|---------|-----------------|-------------|-------------|
-| **Stop hook** (recommended) | yes | yes | no (post-response) | none | `auto_read=true` in `.cc-voice.toml` |
-| Stream-json pipe | no | no | yes | low | `cc-tts-stream "prompt"` |
-| PTY proxy | yes | yes | yes (when working) | high — scrapes Ink output | `cc-tts-wrap claude` |
-
-**Recommended for daily use**: Stop hook. Interactive Claude, full Ink UI, TTS fires after each response. The `SentenceBuffer` splits the full response into sentences so audio starts ~1s after response completes, not at the very end.
-
-See [docs/adr/0001-tts-delivery-modes.md](docs/adr/0001-tts-delivery-modes.md) for the full architectural decision.
-
-### Architecture diagrams
-
-#### Stop hook (recommended)
-
-```text
-claude (interactive, Ink UI)
-    ↓  response complete
-.claude/settings.json hooks.Stop
-    ↓  JSON: {"last_assistant_message": "..."}
-hook_handler.py → load_config, check auto_read
-    ↓  if auto_read=true: spawn detached
-speak.py --stream → speak_streaming()
-    ↓
-edge_stream.py (per engine) → player stdin
-```
-
-#### Stream-json pipe (non-interactive, single prompt)
-
-```text
-cc-tts-stream "your prompt"
-    ↓
-claude -p --output-format stream-json --include-partial-messages
-    ↓  newline-delimited JSON
-stream_json.py → parse text_delta events
-    ↓
-sentence_buffer.py → sentences as they arrive
-    ↓
-tts_worker.py queue → speak_streaming() (streaming per engine)
-```
-
-#### PTY proxy (legacy, Ink-dependent)
-
-```text
-cc-tts-wrap claude
-    ↓
-PTY proxy (pty_proxy.py) ↔ claude (interactive)
-    ↓  raw terminal bytes
-stream_filter.py → ANSI strip, CR normalize, whitelist, code-block skip
-    ↓
-sentence_buffer.py → sentences on ". " / "? " / "! "
-    ↓
-speak.py → engine.synthesize() → player.play_audio()
-```
-
-### How to interrupt voice playback
+## CC Plugin
 
 ```bash
-uv run cc-tts --stop
+claude plugin install cc-voice@local
 ```
 
-Reads the PID file at `~/.cache/cc-voice/speak.pid` and sends SIGTERM to the whole process group (engine + player + children). Works for all delivery modes (Stop hook, stream-json, PTY proxy) — any mode writes the pidfile on start.
+Provides `/speak`, `/listen`, `/see` skills and Stop-hook auto-read.
 
-**Bind to a hotkey** (no code change needed). Pick a key not already used by your shell/editors. Common available choices: Alt+s, F8, Ctrl+\\:
+## Documentation
 
-```bash
-# bash — Alt+s (\\es)
-bind -x '"\es":"uv run cc-tts --stop"'
-
-# zsh — Alt+s
-cc-tts-stop() { uv run cc-tts --stop }
-zle -N cc-tts-stop
-bindkey '^[s' cc-tts-stop
-
-# tmux — prefix + s (or global with -n)
-bind-key s run-shell "uv run cc-tts --stop"
-```
-
-Avoid Ctrl+G (opens nano help), Ctrl+C (sends SIGINT), Ctrl+D (EOF), Ctrl+Z (suspend).
+- [`.cc-voice.example.toml`](.cc-voice.example.toml) — config schema and env vars
+- [Architecture](docs/architecture.md) — pipelines, engines, diagrams, token budgets
+- [User flows](docs/UserStory.md) — personas and end-to-end use cases (incl. hotkey-stop playback)
+- [ADRs](docs/adr/) — decision records (TTS modes, STT engines, VLM screen-sharing)
+- [Roadmap](docs/roadmap/v0.5.x.md) — deferred ideas and rejected paths
+- [Contributing](CONTRIBUTING.md) — setup, conventions, commit style
 
 ## Development
 
 ```bash
-make validate       # lint + type check + test (quiet)
+make validate       # lint + type check + test
 make quick_validate # lint + type check only
 VERBOSE=1 make test # full pytest output
-```
-
-## CC Plugin
-
-Install as Claude Code plugin for `/speak`, `/listen` skills and Stop hook auto-read:
-
-```bash
-claude plugin install cc-voice@local
 ```
 
 ## License

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -1,0 +1,119 @@
+# User Stories
+
+End-to-end flows showing how cc-voice fits into a real working session.
+For the full configuration schema, see [`.cc-voice.example.toml`](../.cc-voice.example.toml).
+For pipeline and engine details, see [architecture.md](architecture.md).
+
+## Personas
+
+- **Solo dev pair-programming aloud** — wants to hear Claude's
+  responses while typing or reading code, occasionally speaking back
+  for hands-free input.
+- **Dev who wants Claude to act on screen content** — feeds the
+  current terminal/editor/browser state into Claude's context as
+  text, so Claude can debug, suggest fixes, or summarize — without
+  paying raw-vision token costs and without manually copy-pasting.
+- **Accessibility user** — relies on bidirectional voice as the
+  primary interaction channel; full Voice Loop must be reliable, not
+  just demo-quality.
+
+## Flow A: Voice Loop
+
+Goal: speak prompts, hear answers, no typing.
+
+Steps:
+
+1. `/speak --toggle` — enables Stop-hook auto-read so every response
+   is spoken once it completes.
+2. `/voice` — enables Claude Code's built-in mic input.
+3. Speak a prompt → Claude transcribes → answers in text → cc-voice
+   reads the answer aloud.
+
+Minimal config (in `.cc-voice.toml`):
+
+```toml
+auto_read = true
+[stt]
+auto_listen = true
+```
+
+The Stop hook splits the response into sentences via `SentenceBuffer`
+so audio starts ~1 s after the response completes, not at the end.
+
+## Flow B: Feed screen content to Claude
+
+Goal: inject the current screen state into Claude's context as text
+so Claude can act on it (debug, suggest a fix, summarize), without
+copy-pasting manually.
+
+Two paths exist:
+
+- **Claude Code's native image analysis** — send the raw screenshot;
+  ~1,600 tokens per call. Best fidelity, but expensive at any
+  reasonable update cadence.
+- **Local VLM/OCR** — run a small vision-language model (or OCR) on
+  device to extract a short text summary; ~120 tokens per call. Lower
+  fidelity, but cheap enough to use repeatedly.
+
+cc-voice's `/see` uses the local path by default.
+
+Steps:
+
+1. `/see --template terminal` — captures the active monitor, runs the
+   local VLM (default Qwen2.5-VL via llama-cpp-python) entirely
+   on-device, and injects the short text description into Claude's
+   prompt.
+2. Claude reads that text alongside the rest of the conversation and
+   responds — e.g., explains a stack trace, proposes a code fix,
+   summarizes editor state.
+3. Iterate: change the screen → re-run `/see`. Cache hits on
+   identical frames cost 0 tokens.
+4. Pick a template that matches what's on screen — narrows the VLM's
+   output and keeps injected context small:
+   - `--template editor` — filename, cursor line, diagnostics
+   - `--template browser` — page title, main heading, banners
+   - `--template gui` — active window, focused element, dialog text
+   - `--template generic` — free-form ≤100-word description
+
+Minimal config:
+
+```toml
+[vlm]
+model_path = "/home/USER/.cache/cc-voice/models/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf"
+mmproj_path = "/home/USER/.cache/cc-voice/models/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf"
+handler_name = "qwen2.5vl"
+```
+
+See [`docs/adr/0003-vlm-screen-sharing.md`](adr/0003-vlm-screen-sharing.md)
+for the rationale behind the in-process VLM choice.
+
+## Flow C: Hotkey-stopped playback
+
+Goal: silence audio instantly when interrupted, without killing the
+shell or REPL.
+
+```bash
+uv run cc-tts --stop
+```
+
+Reads the PID file at `~/.cache/cc-voice/speak.pid` and SIGTERMs the
+whole process group. Works for all delivery modes (Stop hook,
+stream-json, PTY proxy) — every mode writes the pidfile on start.
+
+Bind to a hotkey (no code change). Pick a key not already used by
+your shell/editor — common available choices: Alt+s, F8, Ctrl+\\.
+
+```bash
+# bash — Alt+s (\es)
+bind -x '"\es":"uv run cc-tts --stop"'
+
+# zsh — Alt+s
+cc-tts-stop() { uv run cc-tts --stop }
+zle -N cc-tts-stop
+bindkey '^[s' cc-tts-stop
+
+# tmux — prefix + s (or global with -n)
+bind-key s run-shell "uv run cc-tts --stop"
+```
+
+Avoid Ctrl+G (nano help), Ctrl+C (SIGINT), Ctrl+D (EOF), Ctrl+Z (suspend).

--- a/skills/listen/SKILL.md
+++ b/skills/listen/SKILL.md
@@ -26,21 +26,7 @@ python -m cc_stt $ARGUMENTS
 
 ## Configuration
 
-Edit `.cc-voice.toml` in project root:
-
-```toml
-[stt]
-engine = "auto"          # "moonshine" | "vosk" | "auto"
-language = "en"
-wake_word = "hey_claude"
-mic_device = "default"
-auto_listen = false
-strip_fillers = true     # remove "um", "uh", "like", etc. before sending to LLM
-intent_match = true      # match common commands locally (skip LLM)
-max_words = 200          # hard word cap on transcriptions
-```
-
-Environment overrides: `CC_STT_ENGINE`, `CC_STT_LANGUAGE`, `CC_STT_WAKE_WORD`, `CC_STT_MIC_DEVICE`, `CC_STT_AUTO_LISTEN`, `CC_STT_STRIP_FILLERS`, `CC_STT_INTENT_MATCH`, `CC_STT_MAX_WORDS`.
+See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[stt]` section for the full schema and `CC_STT_*` env overrides.
 
 ## Status
 

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: see
-description: Capture screen content and get a text description via an in-process VLM (llama-cpp-python). No daemon. Use for pair programming, reading terminal output, summarizing editor state, or sharing visual context with Claude with minimal token cost.
+description: Capture the screen and inject a short text summary into Claude's context via an in-process VLM (llama-cpp-python). No daemon. Use to feed terminal/editor/browser state to Claude for debug, fix suggestions, or summarization with minimal token cost.
 compatibility: Designed for Claude Code
 metadata:
   allowed-tools: Bash, Read, Write
@@ -11,7 +11,7 @@ metadata:
 
 # /see
 
-Capture the screen, run a local vision-language model (Qwen2.5-VL by default via llama-cpp-python), and return a short text description for injection into Claude's context. Token-efficient: ~120 tokens per call vs ~1,600 for sending the raw image to Claude's vision API. **No external daemon** — model runs in-process via llama-cpp-python.
+Capture the screen, run a local vision-language model (Qwen2.5-VL by default via llama-cpp-python), and inject a short text description into Claude's context for Claude to act on. ~120 tokens per call vs ~1,600 if you sent the raw image to Claude's vision API. **No external daemon** — model runs in-process via llama-cpp-python.
 
 ## Install — three steps
 
@@ -36,15 +36,7 @@ wget https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Q
 wget https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
 ```
 
-Then configure `.cc-voice.toml`:
-
-```toml
-[vlm]
-engine = "llamacpp"
-model_path = "/home/USER/.cache/cc-voice/models/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf"
-mmproj_path = "/home/USER/.cache/cc-voice/models/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf"
-handler_name = "qwen2.5vl"
-```
+Then point `[vlm].model_path` and `[vlm].mmproj_path` at the downloaded files. See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) for the full `[vlm]` schema.
 
 ## Usage
 
@@ -89,54 +81,13 @@ python -m cc_vlm $ARGUMENTS
 
 ## Configuration
 
-Full `.cc-voice.toml` schema:
+See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[vlm]` section for the full schema and `CC_VLM_*` env overrides. Supported `handler_name` values are listed in [`docs/architecture.md`](../../docs/architecture.md#supported-vlm-models-llama-cpp-python-handlers).
 
-```toml
-[vlm]
-engine = "auto"                     # "auto" | "llamacpp"
-model_path = ""                     # absolute path to .gguf vision model
-mmproj_path = ""                    # absolute path to mmproj (CLIP projector) .gguf
-handler_name = "qwen2.5vl"          # chat handler for this model family (see below)
-n_ctx = 4096                        # context window
-n_gpu_layers = 0                    # 0 = CPU only, -1 = all layers to GPU
-max_tokens = 256                    # max VLM response tokens
-max_dimension = 768                 # resize longest edge before VLM (tokens ∝ dimension²)
-jpeg_quality = 85
-template = "generic"                # default template if --template not passed
-cache_size = 32                     # per-invocation LRU entries
-```
+## Token budget and rationale
 
-**Supported handler_name values**:
+For the in-process-VLM-vs-Claude-Vision token comparison and the rationale for picking llama-cpp-python over Ollama, see [`docs/architecture.md`](../../docs/architecture.md#vlm-token-budget) and [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).
 
-- `qwen2.5vl` → `Qwen25VLChatHandler` (default, works with Qwen2.5-VL-2B/3B/7B)
-- `llava15` → `Llava15ChatHandler` (LLaVA 1.5)
-- `llava16` → `Llava16ChatHandler` (LLaVA 1.6)
-- `moondream` → `MoondreamChatHandler` (Moondream2)
-- `minicpmv` → `MiniCPMv26ChatHandler` (MiniCPM-V 2.6)
-- `nanollava` → `NanollavaChatHandler`
-
-Environment overrides: `CC_VLM_ENGINE`, `CC_VLM_MODEL_PATH`, `CC_VLM_MMPROJ_PATH`, `CC_VLM_HANDLER_NAME`, `CC_VLM_N_CTX`, `CC_VLM_N_GPU_LAYERS`, `CC_VLM_MAX_TOKENS`, `CC_VLM_MAX_DIMENSION`, `CC_VLM_JPEG_QUALITY`, `CC_VLM_TEMPLATE`, `CC_VLM_CACHE_SIZE`.
-
-## Token budget
-
-| Path | Tokens per call | Notes |
-|---|---|---|
-| `/see` (in-process VLM → text) | ~120 | Default. No daemon, no HTTP round-trip. |
-| `/see` cache hit (unchanged screen) | 0 | Frame hashed via BLAKE3; same image+template = no VLM call |
-| Sending raw image to Claude vision (Tier 1, deferred) | ~1,600 | Opt-in via future `--vision` flag |
-
-Prompt templates cap the VLM's output length at the source (e.g., `terminal` says "Max 80 words. Fragments ok."), keeping injected context small regardless of screen content.
-
-## Why llama-cpp-python and not Ollama
-
-cc-voice prefers **lean w/o overhead**:
-
-- **No persistent daemon** — nothing running when `/see` isn't being called (Ollama holds ~2.5 GB RAM idle)
-- **No HTTP layer** — direct in-process Python call
-- **No separate system service** — fewer moving parts, nothing to start/stop
-- **~200-500 ms per-call** in the warm process (the ⭐ latency from ai-agents-research #84)
-
-Trade-off: llama-cpp-python isn't in the `[see]` extras because the correct wheel depends on your hardware (CPU / CUDA / Metal / ROCm). You install the variant matching your machine manually. `make setup_see` prints the three common install commands.
+For an end-to-end user flow (feeding screen content to Claude so it can debug or suggest fixes), see [`docs/UserStory.md`](../../docs/UserStory.md#flow-b-feed-screen-content-to-claude) Flow B.
 
 ## Removing changes made by `/see`
 
@@ -156,12 +107,4 @@ There is **no undo for past descriptions** that were injected into a Claude Code
 
 ## Status
 
-Development — functional MVP. Ships `LlamaCppVLMEngine` only. The following are explicit follow-ups tracked in the 0.4.x hardening roadmap:
-
-- **`OllamaVLMEngine`** — alternative backend for users who already run Ollama for other purposes (routing Claude Code, local chat) and want to reuse the daemon
-- **`ClaudeVisionEngine`** (Tier 1 fallback) — opt-in `--vision` flag to send the raw JPEG to Claude's vision API for cases where the local VLM's text isn't enough
-- **Crop to focused window** — OS-specific (xdotool / wlrctl / AppleScript) to auto-crop before VLM
-- **Auto-template detection** — pick the right template from the focused window's class name
-- **Persistent on-disk cache** — shared across processes (current cache is per-invocation)
-
-See `docs/adr/0003-vlm-screen-sharing.md` for architectural decision.
+Development — functional MVP. Ships `LlamaCppVLMEngine` only. Follow-ups (Ollama backend, Claude Vision opt-in, focused-window crop, auto-template detection, persistent cache) are tracked in the roadmap. See [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -26,36 +26,14 @@ uv run python -m cc_tts.speak $ARGUMENTS
 
 ## Configuration
 
-Edit `.cc-voice.toml` in project root:
+See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[tts]` section for the full schema and `CC_TTS_*` env overrides.
 
-```toml
-[tts]
-engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto"
-voice = "af_sarah"           # kokoro voice name
-speed = 1.0
-auto_read = false
-max_chars = 2000
-player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
-```
+## Delivery modes
 
-Environment overrides: `CC_TTS_ENGINE`, `CC_TTS_VOICE`, `CC_TTS_SPEED`, `CC_TTS_AUTO_READ`.
+Three paths from text to audio (Stop hook, stream-json pipe, PTY proxy). See [`docs/architecture.md`](../../docs/architecture.md#tts-delivery-modes) for the comparison table and [`docs/adr/0001-tts-delivery-modes.md`](../../docs/adr/0001-tts-delivery-modes.md) for the rationale.
 
-## TTS modes
-
-Three delivery paths — see [../../docs/adr/0001-tts-delivery-modes.md](../../docs/adr/0001-tts-delivery-modes.md) for rationale.
-
-| Mode | Start with | Interactive | First audio | Notes |
-|---|---|---|---|---|
-| **Stop hook** (recommended) | `/speak --toggle` | ✓ | ~1-2s after response ends | Full Ink UI, sentence-by-sentence playback via SentenceBuffer |
-| **Stream-json pipe** | `cc-tts-stream "prompt"` | ✗ (one prompt) | ~0.5-1s | True mid-generation streaming, no Ink UI |
-| PTY proxy (legacy) | `cc-tts-wrap claude` | ✓ | ~0.5s if working | Brittle — scrapes Ink output, breaks on CC UI changes |
-
-**Do not combine Stop hook + PTY proxy** — causes double speaking.
+Do not combine Stop hook + PTY proxy — causes double speaking.
 
 ## Voice Loop (STT + TTS)
 
-Enable auto-read then use CC-native `/voice` for full bidirectional voice:
-
-1. `/speak --toggle` (enables auto-read)
-2. `/voice` (enables CC speech-to-text input)
-3. Speak → Claude transcribes → responds → speaks response
+For the full bidirectional flow (`/speak --toggle` → `/voice` → speak → response spoken back), see [`docs/UserStory.md`](../../docs/UserStory.md#flow-a-voice-loop) Flow A.


### PR DESCRIPTION
Closes #60.

## Summary

Steps 1-3 of the doc-hierarchy restructure (slim ADRs, renumber, add `docs/architecture.md`) shipped in v0.6.0. This PR closes the residual three steps in one squash.

Single source of truth for `.cc-voice.toml` is now **`.cc-voice.example.toml`** (per reviewer feedback — the existing example file is the conventional schema doc and doubles as a copy-paste template). The 4-way duplication (README + 3× SKILL.md) collapses into one file:

- Adds 3 missing STT fields (`strip_fillers`, `intent_match`, `max_words`)
- Adds the full `[vlm]` block (11 fields) that was absent
- Lists every `CC_*_*` env override as inline comments

## New: `docs/UserStory.md`

Three end-to-end flows + 3 personas:

- **Flow A: Voice Loop** — bidirectional STT+TTS
- **Flow B: Feed screen content to Claude** — covers the trade-off between Claude Code's native image analysis (~1,600 tok/call) and local VLM/OCR (~120 tok/call). cc-voice's `/see` uses the local path.
- **Flow C: Hotkey-stopped playback** — bash/zsh/tmux examples

## Slimmed

| File | Before | After | Δ |
|---|---:|---:|---:|
| `README.md` | 185 | 73 | -112 |
| `skills/listen/SKILL.md` | 47 | 33 | -14 |
| `skills/speak/SKILL.md` | 61 | 39 | -22 |
| `skills/see/SKILL.md` | 167 | 110 | -57 |
| `.cc-voice.example.toml` | 21 | 43 | +22 |
| `docs/UserStory.md` | — | 119 | +119 |

README keeps the audio-examples table — three WAVs in `assets/audio/` are the core value demo, not hosted elsewhere. SKILL.md files keep all action-oriented content (install steps, local-testing workflows, usage flags). What's removed is duplicated reference material (config schemas, TTS modes table, token-budget table, llama-cpp-python rationale) — now linked to `.cc-voice.example.toml`, `docs/architecture.md`, or ADR-0003.

Net diff: 6 files, +179 / -242 lines.

## Test plan

- [x] `wc -l` on every touched file matches plan targets
- [x] `git diff` shows only docs (no code, no plugin manifests, no version bump needed)
- [x] All cross-links use simplified ASCII anchors (`flow-a-voice-loop`, etc.) — no em-dashes in heading IDs
- [x] Existing ADR cross-links from README + speak/see SKILL.md preserved or upgraded to architecture.md
- [ ] CI link-checker green
- [ ] CI markdownlint green

Generated with Claude <noreply@anthropic.com>