### PR TITLE
chore(gitignore): consolidate phantom-files block, alphabetize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,58 +1,35 @@
-# Claude Code sandbox bug — bwrap creates 0-byte phantom files in working dir
-# Root cause: bwrap bind-mounts resolve paths against cwd instead of $HOME,
-#   and denyWithinAllow strips .git/ prefix from git internals.
-# Mitigation options (pick one):
-#   1. This .gitignore block (cosmetic — hides from git status)
-#   2. Disable sandbox: "sandbox": {"enabled": false} in .claude/settings.json
-#      (devcontainer already provides container-level isolation)
-#   3. PostToolUse cleanup hook in .claude/settings.json:
-#      "hooks": {"PostToolUse": [{"matcher": "Bash",
-#        "hooks": [{"type": "command", "command": "rm -f HEAD config ..."}]}]}
-# Tracking: https://github.com/anthropics/claude-code/issues/17727 (open)
-# Closed incomplete: https://github.com/anthropics/claude-code/issues/17087
-# Worktree impact (open):
-#   https://github.com/anthropics/claude-code/issues/17374 — bwrap fails in worktrees (.git is file)
-#   https://github.com/anthropics/claude-code/issues/29316 — stub files in worktree root
-# Worktree impact (closed, not fully resolved):
-#   https://github.com/anthropics/claude-code/issues/26262 — sandbox restrictions break worktrees
-#   https://github.com/anthropics/claude-code/issues/22320 — bwrap can't mkdir .git/hooks
-#   https://github.com/anthropics/claude-code/issues/27440 — parallel worktree agents lose perms
-#
-# Note: The EnterWorktree tool is also broken by this bug. bwrap's
-#   denyWithinAllow matches HEAD/refs/objects/hooks/config as path suffixes
-#   regardless of depth, so .git/worktrees/<name>/HEAD is blocked the same
-#   as .git/HEAD. This makes git merge/commit impossible inside worktrees.
-#   The /HEAD etc. entries below only affect root-level phantom files —
-#   they do NOT affect .git/worktrees/ (git doesn't track its own internals).
-#   Tested: CC v2.1.52 (Feb 2026). No fix available; sandbox must be disabled
-#   for worktree git operations.
-#
-
-# git internals (denyWithinAllow drops .git/ prefix)
-/HEAD
-/config
-
-# /hooks — disabled, conflicts with plugin hooks/ directory
-/objects
-/refs
-
-# shell dotfiles (cwd instead of $HOME)
+# bwrap sandbox phantom files
+# Bug: $HOME-dotfile deny list resolved against process.cwd() leaks 0-byte
+# char-special /dev/null bind-mount targets into the project root.
+# Tracked: anthropics/claude-code#17727 (open), #17087 (closed incomplete),
+#   #17374 / #29316 (worktree variants — bwrap fails inside worktrees;
+#   EnterWorktree is also broken because denyWithinAllow matches
+#   HEAD/refs/objects/hooks/config as path suffixes at any depth).
+# Alt mitigation: "sandbox": {"enabled": false} in .claude/settings.json
+#   (devcontainer already provides container-level isolation).
+# Full writeup: https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md
 /.bash_profile
 /.bashrc
-/.profile
-/.zprofile
-/.zshrc
-/.gitconfig
-/.gitmodules
-/.mcp.json
-/.ripgreprc
-
-# created as empty files, not dirs — bypass trailing-slash gitignore patterns
 /.claude/agents
 /.claude/commands
 /.claude/skills
+/.gitconfig
+/.gitmodules
 /.idea
+/.mcp.json
+/.profile
+/.ripgreprc
 /.vscode
+/.zprofile
+/.zshrc
+
+# Git internals leaked by denyWithinAllow dropping the .git/ prefix —
+# same root cause class.
+/HEAD
+/config
+# /hooks — disabled, conflicts with tracked plugin hooks/hooks.json
+/objects
+/refs
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary

Refactor of the bwrap sandbox phantom-files block. **Same set of ignored entries — no behavior change.**

## Changes

- Slimmer preamble (10 lines vs 28) — keeps the root cause, tracker references, and alt mitigation pointer
- Single alphabetical list for the dotfile / dir phantoms (was arbitrarily split into "shell dotfiles" + "created as empty files" sub-blocks despite the same root cause)
- Git-internals sub-block kept separate; \`/hooks\` stays commented out (conflicts with the tracked plugin \`hooks/hooks.json\`)
- Adds canonical writeup link: https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/sandboxing/CC-sandbox-bwrap-host-quirks.md

## Test plan

- [x] \`git diff --stat\` — only \`.gitignore\` (+25 / −48 lines, net −23)
- [x] All 18 phantom entries still match \`git check-ignore\`:
  \`\`\`
  .bash_profile, .bashrc, .claude/{agents,commands,skills},
  .gitconfig, .gitmodules, .idea, .mcp.json, .profile,
  .ripgreprc, .vscode, .zprofile, .zshrc,
  HEAD, config, objects, refs
  \`\`\`
- [x] \`hooks\` (without slash) is **not** ignored — \`hooks/hooks.json\` plugin manifest stays tracked
- [x] No code or plugin manifest changes → no version bump

Generated with Claude <noreply@anthropic.com>