### PR TITLE
feat(vlm): promote Moondream2 as recommended default for /see

### DIFF
--- a/.cc-voice.example.toml
+++ b/.cc-voice.example.toml
@@ -32,9 +32,11 @@ max_words = 200              # Hard word cap on transcriptions
 # CC_VLM_JPEG_QUALITY, CC_VLM_TEMPLATE, CC_VLM_CACHE_SIZE)
 [vlm]
 engine = "auto"              # "auto" | "llamacpp"
-model_path = ""              # Absolute path to .gguf vision model
+model_path = ""              # Absolute path to .gguf vision model (set by `make setup_see`)
 mmproj_path = ""             # Absolute path to mmproj (CLIP projector) .gguf
-handler_name = "qwen2.5vl"   # Chat handler — see docs/architecture.md
+handler_name = "moondream"   # Default: Moondream2 (~0.9 GB Q4, fastest CPU path)
+                             # Alt: "qwen2.5vl" (~1.6 GB, richer output) via `make setup_see_qwen25`
+                             # Other handlers — see docs/architecture.md
 n_ctx = 4096                 # Context window
 n_gpu_layers = 0             # 0 = CPU only, -1 = all layers to GPU
 max_tokens = 256             # Max VLM response tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@
 ### Added
 
 - docs: `docs/UserStory.md` — three end-to-end flows (Voice Loop, screen-content-to-Claude, hotkey-stopped playback) and three personas (#83)
+- feat(make): `setup_see` and `setup_see_qwen25` Makefile targets — install `--extra see`, download the GGUF + mmproj into `~/.cache/cc-voice/models/`, detect host hardware and print the matching `llama-cpp-python` install command, then print the `[vlm]` snippet for `.cc-voice.toml` (#91)
+- test(make): `tests/test_makefile_targets.py` smoke-tests the new setup_see targets via `make -n` dry-run (#91)
 
 ### Changed
 
 - docs: dedupe config schema — `.cc-voice.example.toml` is the single source of truth for `.cc-voice.toml` fields and `CC_*` env overrides; README and `skills/*/SKILL.md` link to it instead of embedding partial copies. README slimmed 185 → 73 lines; SKILL.md sum 275 → 182 lines (#83, closes #60)
 - chore: slim `.cc-voice.toml` from 47 to 8 lines — removes the duplicated full schema; only fields that override the example defaults remain. Behavior unchanged; `.cc-voice.example.toml` is now the canonical schema reference (#87, refs #60)
 - docs(roadmap): mark v0.5.0/v0.6.0 as shipped; drop closed #29/#33/#34 from "Tracked" (#81)
+- feat(vlm): default VLM handler flips from `qwen2.5vl` to `moondream` — Moondream2 is sub-1 GB Q4 GGUF, Apache 2.0, fastest CPU path; Qwen2.5-VL handler stays available as alt (#91)
+- docs(vlm): `skills/see/SKILL.md` install section collapsed from ~22 lines to ~6; all hardcoded Hugging Face + abetlen wheel-index URLs moved to `Makefile` variables — single source of truth. `docs/UserStory.md` Flow B and `docs/architecture.md` handler table updated to reflect Moondream2 default (#91)
+
+### Fixed
+
+- fix(vlm): replace inline Hugging Face URL in "No VLM engine available" `RuntimeError` with `make setup_see` pointer (#91)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .SILENT:
 .ONESHELL:
-.PHONY: setup setup_dev setup_espeak setup_piper setup_kokoro setup_stt setup_user setup_all clean validate lint_fix quick_validate lint_src lint_tests lint_md lint_links type_check test test_coverage speak wrap bump_patch bump_minor bump_major help
+.PHONY: \
+	setup setup_dev setup_espeak setup_piper setup_kokoro setup_stt \
+	setup_see setup_see_qwen25 setup_user setup_all \
+	clean validate lint_fix quick_validate lint_src lint_tests lint_md lint_links \
+	type_check test test_coverage speak wrap \
+	bump_patch bump_minor bump_major help
 .DEFAULT_GOAL := help
 
 # -- quiet mode (default: quiet; set VERBOSE=1 for full output) --
@@ -10,6 +15,16 @@ ifndef VERBOSE
   PYTEST_QUIET := -q --tb=short --no-header
   COV_QUIET    := --cov-report=
 endif
+
+# -- VLM model + llama-cpp-python wheel URLs (single source of truth) --
+# Update these vars when bumping recommended models or wheel index URLs.
+VLM_MODELS_DIR          := $(HOME)/.cache/cc-voice/models
+VLM_MOONDREAM_MODEL_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-text-model-f16_ct-q4_0.gguf
+VLM_MOONDREAM_MMPROJ_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-mmproj-f16.gguf
+VLM_QWEN25_MODEL_URL    := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
+VLM_QWEN25_MMPROJ_URL   := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
+LLAMA_CPP_INDEX_CPU     := https://abetlen.github.io/llama-cpp-python/whl/cpu
+LLAMA_CPP_INDEX_CUDA124 := https://abetlen.github.io/llama-cpp-python/whl/cu124
 
 
 # MARK: SETUP
@@ -42,6 +57,65 @@ setup_kokoro: ## Install Kokoro TTS (best local quality, ~82MB model)
 
 setup_stt: ## Install STT deps (sounddevice + default engine)
 	uv sync --extra stt
+
+setup_see: ## Install /see deps + download Moondream2 (recommended default VLM)
+	uv sync --extra see
+	mkdir -p $(VLM_MODELS_DIR)
+	model=$(VLM_MODELS_DIR)/moondream2-text-model-f16_ct-q4_0.gguf
+	mmproj=$(VLM_MODELS_DIR)/moondream2-mmproj-f16.gguf
+	if [ ! -f $$model ]; then
+		echo "Downloading Moondream2 model ..."
+		curl -fL --retry 3 -o $$model $(VLM_MOONDREAM_MODEL_URL)
+	else
+		echo "Moondream2 model already present — skipping."
+	fi
+	if [ ! -f $$mmproj ]; then
+		echo "Downloading Moondream2 mmproj ..."
+		curl -fL --retry 3 -o $$mmproj $(VLM_MOONDREAM_MMPROJ_URL)
+	else
+		echo "Moondream2 mmproj already present — skipping."
+	fi
+	echo ""
+	echo "  Now install llama-cpp-python for your hardware (NOT auto-installed):"
+	if [ "$$(uname -s)" = "Darwin" ]; then
+		echo "    CMAKE_ARGS='-DLLAMA_METAL=on' uv pip install llama-cpp-python    # macOS Metal"
+	elif command -v nvidia-smi > /dev/null 2>&1; then
+		echo "    uv pip install llama-cpp-python --extra-index-url $(LLAMA_CPP_INDEX_CUDA124)    # CUDA 12.4 detected"
+	else
+		echo "    uv pip install llama-cpp-python --extra-index-url $(LLAMA_CPP_INDEX_CPU)    # CPU"
+	fi
+	echo ""
+	echo "  Then add this to .cc-voice.toml:"
+	echo ""
+	echo "    [vlm]"
+	echo "    model_path = \"$$model\""
+	echo "    mmproj_path = \"$$mmproj\""
+	echo "    handler_name = \"moondream\""
+
+setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (alt VLM, richer output)
+	uv sync --extra see
+	mkdir -p $(VLM_MODELS_DIR)
+	model=$(VLM_MODELS_DIR)/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
+	mmproj=$(VLM_MODELS_DIR)/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
+	if [ ! -f $$model ]; then
+		echo "Downloading Qwen2.5-VL-3B model ..."
+		curl -fL --retry 3 -o $$model $(VLM_QWEN25_MODEL_URL)
+	else
+		echo "Qwen2.5-VL-3B model already present — skipping."
+	fi
+	if [ ! -f $$mmproj ]; then
+		echo "Downloading Qwen2.5-VL-3B mmproj ..."
+		curl -fL --retry 3 -o $$mmproj $(VLM_QWEN25_MMPROJ_URL)
+	else
+		echo "Qwen2.5-VL-3B mmproj already present — skipping."
+	fi
+	echo ""
+	echo "  Then add this to .cc-voice.toml:"
+	echo ""
+	echo "    [vlm]"
+	echo "    model_path = \"$$model\""
+	echo "    mmproj_path = \"$$mmproj\""
+	echo "    handler_name = \"qwen2.5vl\""
 
 setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no dev tools)
 	@echo ""

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -60,7 +60,7 @@ cc-voice's `/see` uses the local path by default.
 Steps:
 
 1. `/see --template terminal` — captures the active monitor, runs the
-   local VLM (default Qwen2.5-VL via llama-cpp-python) entirely
+   local VLM (default Moondream2 via llama-cpp-python) entirely
    on-device, and injects the short text description into Claude's
    prompt.
 2. Claude reads that text alongside the rest of the conversation and
@@ -75,13 +75,13 @@ Steps:
    - `--template gui` — active window, focused element, dialog text
    - `--template generic` — free-form ≤100-word description
 
-Minimal config:
+Minimal config (run `make setup_see` to populate the paths):
 
 ```toml
 [vlm]
-model_path = "/home/USER/.cache/cc-voice/models/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf"
-mmproj_path = "/home/USER/.cache/cc-voice/models/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf"
-handler_name = "qwen2.5vl"
+model_path = "/home/USER/.cache/cc-voice/models/moondream2-text-model-f16_ct-q4_0.gguf"
+mmproj_path = "/home/USER/.cache/cc-voice/models/moondream2-mmproj-f16.gguf"
+handler_name = "moondream"
 ```
 
 See [`docs/adr/0003-vlm-screen-sharing.md`](adr/0003-vlm-screen-sharing.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,12 +94,15 @@ Cold start: 3-5 s (model load). Warm page cache: 1-2 s. In-process reuse: 200-50
 
 | handler_name | llama_cpp class | Model family |
 |---|---|---|
-| `qwen2.5vl` (default) | `Qwen25VLChatHandler` | Qwen2.5-VL-2B/3B/7B |
+| `moondream` (default) | `MoondreamChatHandler` | Moondream2 (~0.9 GB Q4, fastest CPU path) |
+| `qwen2.5vl` | `Qwen25VLChatHandler` | Qwen2.5-VL-2B/3B/7B (richer output, ~1.6 GB Q4) |
 | `llava15` | `Llava15ChatHandler` | LLaVA 1.5 |
 | `llava16` | `Llava16ChatHandler` | LLaVA 1.6 |
-| `moondream` | `MoondreamChatHandler` | Moondream2 |
 | `minicpmv` | `MiniCPMv26ChatHandler` | MiniCPM-V 2.6 |
 | `nanollava` | `NanollavaChatHandler` | NanoLLaVA |
+
+Default chosen for smallest CPU footprint; install via `make setup_see`.
+For richer output swap to `qwen2.5vl` via `make setup_see_qwen25`.
 
 ### VLM token budget
 

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -29,6 +29,7 @@ Filed alongside this roadmap — see each issue for full scope + acceptance crit
 - **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr (multilingual, CC-BY-4.0)`
 - **#45** — `bug(plugin): stale plugin cache not refreshed from local directory source`
 - **#60** — `docs: restructure doc hierarchy — slim ADRs, add architecture.md, UserStory.md`
+- **#91** — `feat(vlm): promote Moondream2 as recommended default for /see`
 
 When one of these lands, link back to this file if scope expanded or contracted.
 

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -11,32 +11,17 @@ metadata:
 
 # /see
 
-Capture the screen, run a local vision-language model (Qwen2.5-VL by default via llama-cpp-python), and inject a short text description into Claude's context for Claude to act on. ~120 tokens per call vs ~1,600 if you sent the raw image to Claude's vision API. **No external daemon** — model runs in-process via llama-cpp-python.
+Capture the screen, run a local vision-language model (Moondream2 by default via llama-cpp-python), and inject a short text description into Claude's context for Claude to act on. ~120 tokens per call vs ~1,600 if you sent the raw image to Claude's vision API. **No external daemon** — model runs in-process via llama-cpp-python.
 
-## Install — three steps
+## Install
 
 ```bash
-# 1. Core scaffolding deps (mss, Pillow, blake3)
-make setup_see
-
-# 2. llama-cpp-python (pick ONE matching your hardware)
-#    See `make setup_see` output for the exact commands.
-#    Examples:
-uv pip install 'llama-cpp-python' \
-  --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
-# or CUDA 12.4:
-# uv pip install 'llama-cpp-python' --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124
-# or Metal:
-# CMAKE_ARGS='-DLLAMA_METAL=on' uv pip install llama-cpp-python
-
-# 3. Download the Qwen2.5-VL GGUF + mmproj files
-mkdir -p ~/.cache/cc-voice/models
-cd ~/.cache/cc-voice/models
-wget https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
-wget https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
+make setup_see           # default: Moondream2 (~0.9 GB Q4, fastest CPU)
+# or
+make setup_see_qwen25    # alt: Qwen2.5-VL-3B (~1.6 GB Q4, richer output)
 ```
 
-Then point `[vlm].model_path` and `[vlm].mmproj_path` at the downloaded files. See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) for the full `[vlm]` schema.
+Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-voice/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-voice.toml`. See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) for the full `[vlm]` schema.
 
 ## Usage
 

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -17,7 +17,7 @@ class VLMConfig(BaseSettings):
     engine: str = "auto"
     model_path: str = ""
     mmproj_path: str = ""
-    handler_name: str = "qwen2.5vl"
+    handler_name: str = "moondream"
     n_ctx: int = 4096
     n_gpu_layers: int = 0
     max_tokens: int = 256

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -70,7 +70,7 @@ class LlamaCppVLMEngine:
         self,
         model_path: str = "",
         mmproj_path: str = "",
-        handler_name: str = "qwen2.5vl",
+        handler_name: str = "moondream",
         n_ctx: int = 4096,
         n_gpu_layers: int = 0,
         max_tokens: int = 256,

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -211,11 +211,11 @@ def resolve_vlm_engine(
             return engine
 
     msg = (
-        "No VLM engine available. Install `uv sync --extra see` and set "
-        "[vlm] model_path + mmproj_path in .cc-voice.toml (or export "
-        "CC_VLM_MODEL_PATH and CC_VLM_MMPROJ_PATH). Download a Qwen2.5-VL "
-        "GGUF + mmproj from Hugging Face, e.g. "
-        "https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF"
+        "No VLM engine available. Run `make setup_see` for guided "
+        "installation (downloads models, prints the matching "
+        "llama-cpp-python install command for your hardware). Then set "
+        "[vlm] model_path + mmproj_path in .cc-voice.toml or export "
+        "CC_VLM_MODEL_PATH and CC_VLM_MMPROJ_PATH."
     )
     raise RuntimeError(msg)
 

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,71 @@
+"""Smoke tests for Makefile setup_* targets.
+
+Verifies the targets exist and dry-run-print the expected commands.
+Run via `make -n <target>`; output is parsed for required substrings.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def make_available() -> None:
+    if shutil.which("make") is None:
+        pytest.skip("make not available in this environment")
+
+
+def _make_dry_run(target: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["make", "-n", target],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestSetupSee:
+    def test_setup_see_target_exists(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see")
+        assert result.returncode == 0, (
+            f"setup_see target missing — stderr: {result.stderr}"
+        )
+
+    def test_setup_see_runs_uv_sync_with_see_extra(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see")
+        assert "uv sync --extra see" in result.stdout
+
+    def test_setup_see_references_moondream_model(self, make_available: None) -> None:
+        """Default downloads must point at Moondream2 GGUF + mmproj."""
+        result = _make_dry_run("setup_see")
+        out = result.stdout.lower()
+        assert "moondream" in out
+
+    def test_setup_see_does_not_reference_qwen25_as_default(
+        self, make_available: None
+    ) -> None:
+        """The Qwen2.5-VL alt is in setup_see_qwen25, not the default target."""
+        result = _make_dry_run("setup_see")
+        # The dry-run output for setup_see should not pull in Qwen2.5-VL URLs.
+        assert "qwen2.5-vl" not in result.stdout.lower()
+
+
+class TestSetupSeeQwen25:
+    def test_setup_see_qwen25_target_exists(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see_qwen25")
+        assert result.returncode == 0, (
+            f"setup_see_qwen25 target missing — stderr: {result.stderr}"
+        )
+
+    def test_setup_see_qwen25_references_qwen25_model(
+        self, make_available: None
+    ) -> None:
+        result = _make_dry_run("setup_see_qwen25")
+        assert "Qwen2.5-VL" in result.stdout

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -15,7 +15,7 @@ class TestVLMConfigDefaults:
         assert config.engine == "auto"
         assert config.model_path == ""
         assert config.mmproj_path == ""
-        assert config.handler_name == "qwen2.5vl"
+        assert config.handler_name == "moondream"
         assert config.n_ctx == 4096
         assert config.n_gpu_layers == 0
         assert config.max_tokens == 256

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -352,6 +352,17 @@ class TestResolveVLMEngine:
         with pytest.raises(RuntimeError, match="No VLM engine available"):
             resolve_vlm_engine("auto")
 
+    def test_auto_unavailable_message_points_at_setup_see(
+        self,
+        mock_llama_cpp: tuple[MagicMock, MagicMock, MagicMock],
+    ) -> None:
+        """Error message must reference `make setup_see`, not a hardcoded HF URL."""
+        with pytest.raises(RuntimeError) as exc_info:
+            resolve_vlm_engine("auto")
+        message = str(exc_info.value)
+        assert "make setup_see" in message
+        assert "huggingface.co" not in message
+
     def test_explicit_llamacpp_name(
         self,
         mock_llama_cpp: tuple[MagicMock, MagicMock, MagicMock],

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -44,6 +44,7 @@ def mock_llama_cpp() -> tuple[MagicMock, MagicMock, MagicMock]:
     # Chat handler classes — each is itself a callable returning a mock
     fake_chat_format_module.Qwen25VLChatHandler = MagicMock(return_value=MagicMock())
     fake_chat_format_module.Llava15ChatHandler = MagicMock(return_value=MagicMock())
+    fake_chat_format_module.MoondreamChatHandler = MagicMock(return_value=MagicMock())
 
     saved_llama = sys.modules.get("llama_cpp")
     saved_chat = sys.modules.get("llama_cpp.llama_chat_format")
@@ -94,7 +95,7 @@ class TestLlamaCppVLMEngineDefaults:
         engine = LlamaCppVLMEngine()
         assert engine.model_path == ""
         assert engine.mmproj_path == ""
-        assert engine.handler_name == "qwen2.5vl"
+        assert engine.handler_name == "moondream"
         assert engine.n_ctx == 4096
         assert engine.n_gpu_layers == 0
         assert engine.max_tokens == 256
@@ -175,6 +176,22 @@ class TestLlamaCppVLMEngineAvailable:
         model.write_bytes(b"x")
         mmproj.write_bytes(b"x")
         engine = LlamaCppVLMEngine(model_path=str(model), mmproj_path=str(mmproj))
+        assert engine.available() is True
+
+    def test_available_with_moondream_handler(
+        self,
+        mock_llama_cpp: tuple[MagicMock, MagicMock, MagicMock],
+        tmp_path: Path,
+    ) -> None:
+        model = tmp_path / "m.gguf"
+        mmproj = tmp_path / "mm.gguf"
+        model.write_bytes(b"x")
+        mmproj.write_bytes(b"x")
+        engine = LlamaCppVLMEngine(
+            model_path=str(model),
+            mmproj_path=str(mmproj),
+            handler_name="moondream",
+        )
         assert engine.available() is True
 
 
@@ -346,6 +363,24 @@ class TestResolveVLMEngine:
         mmproj.write_bytes(b"x")
         engine = resolve_vlm_engine("llamacpp", model_path=str(model), mmproj_path=str(mmproj))
         assert isinstance(engine, LlamaCppVLMEngine)
+
+    def test_auto_resolves_with_moondream_handler(
+        self,
+        mock_llama_cpp: tuple[MagicMock, MagicMock, MagicMock],
+        tmp_path: Path,
+    ) -> None:
+        model = tmp_path / "m.gguf"
+        mmproj = tmp_path / "mm.gguf"
+        model.write_bytes(b"x")
+        mmproj.write_bytes(b"x")
+        engine = resolve_vlm_engine(
+            "auto",
+            model_path=str(model),
+            mmproj_path=str(mmproj),
+            handler_name="moondream",
+        )
+        assert isinstance(engine, LlamaCppVLMEngine)
+        assert engine.handler_name == "moondream"
 
     def test_unknown_engine_name_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown engine"):


### PR DESCRIPTION
## Summary

- Promote **Moondream2** as the recommended default VLM for `/see` — Apache 2.0, ~0.9 GB Q4 GGUF, fastest CPU path, already in `_HANDLER_MAP`. Qwen2.5-VL handler stays available as alt.
- Add `make setup_see` (default: Moondream2) and `make setup_see_qwen25` (alt: Qwen2.5-VL-3B) — close the long-standing gap referenced from `skills/see/SKILL.md:19` and `engine.py:229`.
- Centralize all VLM model + `llama-cpp-python` wheel-index URLs into Makefile variables — single source of truth. Drop the four hardcoded HF URLs from `skills/see/SKILL.md`, `docs/UserStory.md`, and `src/cc_vlm/engine.py`.

Closes #91.

## Background

Closed ADR work (#33) committed Qwen3-VL-2B + LFM2-VL-3B as future targets, but external research (2026-05-06) confirmed both are blocked:

- **Qwen3-VL-2B**: handler missing from upstream `abetlen/llama-cpp-python` ([#2080](https://github.com/abetlen/llama-cpp-python/issues/2080)).
- **LFM2-VL-3B**: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and a non-Apache license with revenue cap.

Moondream2 was the only top-3 candidate that required zero new code today — all the other improvements are scope-deferred to follow-up issues (SmolVLM2-via-llama-server, Qwen3-VL when handler ships, `available()` hardening).

## Commits (TDD: Red → Green per unit)

```
test(vlm): assert default handler_name == moondream
feat(vlm): default Moondream2 handler in config + engine
test(vlm): error message points at make setup_see, not HF URL
fix(vlm): replace inline HF URL with make setup_see pointer
test(make): smoke test for setup_see targets
feat(make): add setup_see + setup_see_qwen25 targets
docs(vlm): point /see install at Moondream2; remove hardcoded URLs
docs(changelog): record #91 entries under [Unreleased]
```

## Test plan

- [x] `pytest tests/test_vlm_config.py tests/test_vlm_engine.py tests/test_vlm_templates.py tests/test_makefile_targets.py` → 46 passed
- [x] `git grep huggingface skills docs src` → only the unrelated Piper voice URL in `cc_tts/engine.py` remains
- [ ] Manual smoke (reviewer): `make setup_see` on a clean checkout → downloads Moondream2 GGUF + mmproj, prints hardware-matched `llama-cpp-python` install command, prints `[vlm]` snippet
- [ ] Manual smoke (reviewer with weights present): `python -m cc_vlm --image-file <PNG>` → text description returned

## Notes

- `tests/test_vlm_cache.py`, `test_vlm_capture.py`, `test_vlm_main.py`, `test_vlm_processor.py` fail to collect on `main` due to `PIL` not being installed in the dev venv (pre-existing). `test_edge_stream.py` and `test_stt_mic.py` also have pre-existing failures on `main`. Confirmed unaffected by this PR.
- Plugin-versioning rule: this repo bumps via `.github/workflows/bump-my-version.yaml` workflow rather than per-PR. Recorded under `[Unreleased]` in CHANGELOG.md per recent project convention (#87, #88).

Generated with Claude <noreply@anthropic.com>
