### PR TITLE
chore: post-VLM cleanup — README VLM bullet, CHANGELOG dedup, badge URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@
 ### Fixed
 
 - fix(vlm): replace inline Hugging Face URL in "No VLM engine available" `RuntimeError` with `make setup_see` pointer (#91)
-
-### Fixed
-
 - fix(config): wrap TTS keys in `[tts]` section in `.cc-voice.example.toml` — top-level TTS keys were silently ignored by the `load_toml_section("tts")` loader (#83)
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CodeQL](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype/badge)](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype)
 [![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)
-[![Link Checker](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/links-fail-fast.yaml)
+[![Lint MD and Links](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/lint-md-links.yml)
 
 End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk, VLM ingests the screen and feeds it as text into Claude's context for Claude to act on.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, ST
 
 - **TTS** — `/speak` skill, Stop-hook auto-read, multi-engine (Kokoro / Piper / espeak-ng / edge-tts)
 - **STT** — `/listen` skill, Moonshine/Vosk auto-detect, mic capture with VAD, PTY injection
-- **VLM** — `/see` skill, in-process Qwen2.5-VL via llama-cpp-python, screen → text into Claude's context (~120 tokens/call vs ~1,600 raw vision)
+- **VLM** — `/see` skill, in-process Moondream2 via llama-cpp-python (Qwen2.5-VL alt), screen → text into Claude's context (~120 tokens/call vs ~1,600 raw vision)
 
 ## Audio Examples
 


### PR DESCRIPTION
## Summary

Three small follow-up cleanups after PR #92 (Moondream2 default).

- `README.md` Features bullet still listed Qwen2.5-VL as the in-process VLM — flipped to Moondream2 (default) with Qwen2.5-VL noted as alt.
- `CHANGELOG.md` `[Unreleased]` had two `### Fixed` subsections after the #91 sweep; markdownlint MD024 flagged the duplicate. Merged into one.
- `README.md` Link Checker badge URL pointed at a non-existent `links-fail-fast.yaml` workflow → 404 from lychee. Repointed at the actual workflow `.github/workflows/lint-md-links.yml` (display name "Lint MD and Links").

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK, 0 errors

## Test plan

- [x] markdownlint passes on all `*.md`, `assets/**/*.md`, `.claude/**/*.md`
- [x] lychee passes on all `*.md`, `assets/**/*.md`, `.claude/**/*.md`

Generated with Claude <noreply@anthropic.com>
