### PR TITLE
docs(skills): drop redundant H1 — title lives in frontmatter

### DIFF
--- a/skills/listen/SKILL.md
+++ b/skills/listen/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   stability: development
 ---
 
-# /listen
-
 Transcribe speech using local speech-to-text.
 
 ## Usage

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -9,8 +9,6 @@ metadata:
   stability: development
 ---
 
-# /see
-
 Capture the screen, run a local vision-language model (Moondream2 by default via llama-cpp-python), and inject a short text description into Claude's context for Claude to act on. ~120 tokens per call vs ~1,600 if you sent the raw image to Claude's vision API. **No external daemon** — model runs in-process via llama-cpp-python.
 
 ## Install

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -8,8 +8,6 @@ metadata:
   stability: development
 ---
 
-# /speak
-
 Speak text aloud using local text-to-speech.
 
 ## Usage


### PR DESCRIPTION
## Summary

Each `skills/*/SKILL.md` had YAML frontmatter declaring `name: listen|see|speak` AND a duplicated body H1 (`# /listen`, `# /see`, `# /speak`). Skill loaders read frontmatter as the single source of truth for the title, so the H1 is redundant and drift-prone.

Drop the H1 from all three; body now opens with the descriptive paragraph.

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

Generated with Claude <noreply@anthropic.com>
