### PR TITLE
docs: post-merge sync — CHANGELOG #93/#94, drop closed #91 from roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@
 - docs(roadmap): mark v0.5.0/v0.6.0 as shipped; drop closed #29/#33/#34 from "Tracked" (#81)
 - feat(vlm): default VLM handler flips from `qwen2.5vl` to `moondream` — Moondream2 is sub-1 GB Q4 GGUF, Apache 2.0, fastest CPU path; Qwen2.5-VL handler stays available as alt (#91)
 - docs(vlm): `skills/see/SKILL.md` install section collapsed from ~22 lines to ~6; all hardcoded Hugging Face + abetlen wheel-index URLs moved to `Makefile` variables — single source of truth. `docs/UserStory.md` Flow B and `docs/architecture.md` handler table updated to reflect Moondream2 default (#91)
+- docs(readme): Features bullet flipped to Moondream2 (Qwen2.5-VL noted as alt) (#93)
+- docs(skills): drop redundant `# /listen|/see|/speak` H1 from each `skills/*/SKILL.md` body — title is already in YAML frontmatter `name:`; removes drift surface (#94)
 
 ### Fixed
 
 - fix(vlm): replace inline Hugging Face URL in "No VLM engine available" `RuntimeError` with `make setup_see` pointer (#91)
 - fix(config): wrap TTS keys in `[tts]` section in `.cc-voice.example.toml` — top-level TTS keys were silently ignored by the `load_toml_section("tts")` loader (#83)
+- fix(readme): Link Checker badge URL pointed at non-existent `links-fail-fast.yaml` workflow — repointed at `lint-md-links.yml` (#93)
+- chore(changelog): merge duplicate `### Fixed` subsections under `[Unreleased]` to satisfy markdownlint MD024 (#93)
 
 ### Removed
 

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -29,7 +29,6 @@ Filed alongside this roadmap — see each issue for full scope + acceptance crit
 - **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr (multilingual, CC-BY-4.0)`
 - **#45** — `bug(plugin): stale plugin cache not refreshed from local directory source`
 - **#60** — `docs: restructure doc hierarchy — slim ADRs, add architecture.md, UserStory.md`
-- **#91** — `feat(vlm): promote Moondream2 as recommended default for /see`
 
 When one of these lands, link back to this file if scope expanded or contracted.
 


### PR DESCRIPTION
## Summary

Two doc-sync gaps the previous merges missed:

- `CHANGELOG.md` `[Unreleased]` had #91 entries but no entries for #93 or #94 (the two post-VLM cleanup PRs). Added them under `### Changed` and `### Fixed`.
- `docs/roadmap/v0.5.x.md` "Tracked in GitHub issues (actionable)" still listed `#91` even though it merged on 2026-05-06. Dropped the stale entry.

The "Recently shipped" version-table row will be added when the next bump-my-version PR rolls up #91 / #92 / #93 / #94 — per project convention version bumps go through `.github/workflows/bump-my-version.yaml`, not per-feature-PR.

Refs #85 (roadmap drift prevention discussion).

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

Generated with Claude <noreply@anthropic.com>
