### PR TITLE
docs(roadmap): record three rejected directions — LFM2-VL, omnivoice, TEN

### DIFF
--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -91,6 +91,9 @@ here to prevent re-research in future sessions.
 | **PersonaPlex adoption** | Scope mismatch — replaces Claude Code's LLM entirely. cc-voice's value prop is "Claude Code does the thinking". Only useful as a future-direction note (deferred idea above). |
 | **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-voice doesn't need to re-document external tools. |
 | **`context-mode`** deep research | Unresearched, not urgent. Revisit only if `rtk`'s command-output compression proves insufficient. |
+| **LFM2-VL-3B** (Liquid AI) | Two blockers: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and LFM Open License v1.0 imposes a $10M revenue cap (not Apache 2.0). Revisit only if the bug closes AND the license relaxes. |
+| **k2-fsa/omnivoice** as TTS engine | Apache 2.0 header but model card adds "academic research purposes only" disclaimer; GPU/MPS-only inference path documented (no CPU/ONNX/GGUF). Existing TTS engines (kokoro/piper/espeak) all run CPU-only. Revisit if a clean Apache export with quantized CPU path ships. |
+| **TEN-framework** (Agora) as cc-voice base | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-voice hard constraint violated. |
 
 ## Process notes
 


### PR DESCRIPTION
## Summary

Append three verified-rejected entries to `docs/roadmap/v0.5.x.md` "Rejected directions — do NOT reconsider without new evidence" so they aren't re-researched in future sessions:

- **LFM2-VL-3B** (Liquid AI) — active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) + LFM Open License v1.0's $10M revenue cap (not Apache 2.0). Verified during the #91 research pass.
- **k2-fsa/omnivoice** as TTS engine — Apache 2.0 header but model card adds "academic research purposes only" disclaimer; GPU/MPS-only inference path; no CPU/ONNX/GGUF. Existing TTS engines all run CPU-only.
- **TEN-framework** (Agora) — non-OSI clauses on top of Apache 2.0 forbid end-user-device hosting; daemon-required runtime; cloud-only bundled STT/TTS; full-duplex by design. Every cc-voice hard constraint violated.

## Why now

cc-voice's roadmap convention (lines 78-93) records rejected paths so they aren't re-researched. LFM2-VL has been known-rejected since #91; the two GitHub repos were assessed today. Single-commit PR adds all three rows in one pass per the existing register.

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

Generated with Claude <noreply@anthropic.com>
