### PR TITLE
docs(arch): replace OllamaVLMEngine (planned) with LlamaServerVLMEngine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,10 @@ Engine priority (auto-detect order): `llamacpp` (only MVP engine)
 | Engine | Backend | Daemon | RAM idle | Latency (warm) | Notes |
 |---|---|---|---|---|---|
 | **llamacpp** (default) | llama-cpp-python | None | 0 | ~200-500 ms | In-process; no HTTP |
-| OllamaVLMEngine (planned) | Ollama | Yes | ~2.5 GB | ~200-500 ms | For users already running Ollama |
+| LlamaServerVLMEngine (planned) | `llama-server` HTTP | Yes (user-managed) | ~1-2 GB | ~200-500 ms | Same llama.cpp binary as in-process; unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs |
 | ClaudeVisionEngine (deferred) | Claude Vision API | None | 0 | ~1-3 s | ~1,600 tokens/call; opt-in `--vision` |
+
+**Why `llama-server` and not Ollama**: same llama.cpp binary already used by the in-process path, no extra daemon family to support, no Ollama-as-dependency. Ollama was considered and rejected on those grounds during the #91 research pass.
 
 BLAKE3 frame cache: unchanged screen + same template = 0 VLM calls.
 Cold start: 3-5 s (model load). Warm page cache: 1-2 s. In-process reuse: 200-500 ms.


### PR DESCRIPTION
## Summary

`docs/architecture.md` VLM engine-comparison table listed `OllamaVLMEngine (planned)` as the next backend. The #91 research pass and follow-up plan explicitly chose `llama-server` over Ollama:

- Same llama.cpp binary already used by the in-process path → no extra daemon *family* to support
- No Ollama-as-dependency
- Unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs

Replace the row and add a one-line "why not Ollama" footnote so readers see the rationale inline.

The actual `LlamaServerVLMEngine` implementation stays tracked as a separate VLM Phase 2 issue (to be filed alongside the SmolVLM2 / Qwen3-VL / `available()`-hardening trackers).

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

## Note

`src/cc_vlm/engine.py:182` docstring still mentions `OllamaVLMEngine alternative` — that's the same drift one layer down. Out of scope for this single-line doc fix; will be reconciled when Phase 2 is filed.

Generated with Claude <noreply@anthropic.com>
