### PR TITLE
docs(vlm): finish post-#91 drift sweep — Moondream default + llama-server

### DIFF
--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -68,7 +68,7 @@ See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[vlm]` section for
 
 ## Token budget and rationale
 
-For the in-process-VLM-vs-Claude-Vision token comparison and the rationale for picking llama-cpp-python over Ollama, see [`docs/architecture.md`](../../docs/architecture.md#vlm-token-budget) and [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).
+For the in-process-VLM-vs-Claude-Vision token comparison and the rationale for picking in-process `llama-cpp-python` over external daemons (Ollama, llama-server), see [`docs/architecture.md`](../../docs/architecture.md#vlm-engine-comparison) and [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).
 
 For an end-to-end user flow (feeding screen content to Claude so it can debug or suggest fixes), see [`docs/UserStory.md`](../../docs/UserStory.md#flow-b-feed-screen-content-to-claude) Flow B.
 
@@ -90,4 +90,4 @@ There is **no undo for past descriptions** that were injected into a Claude Code
 
 ## Status
 
-Development — functional MVP. Ships `LlamaCppVLMEngine` only. Follow-ups (Ollama backend, Claude Vision opt-in, focused-window crop, auto-template detection, persistent cache) are tracked in the roadmap. See [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).
+Development — functional MVP. Ships `LlamaCppVLMEngine` only. Follow-ups (`LlamaServerVLMEngine` HTTP backend, Claude Vision opt-in, focused-window crop, auto-template detection, persistent cache) are tracked in the roadmap. See [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -57,11 +57,11 @@ class LlamaCppVLMEngine:
     Within a single Python process after first call: 200-500 ms per
     describe() (the ⭐ latency cited in ai-agents-research #84).
 
-    Default handler is Qwen2.5-VL. For other model families set
+    Default handler is Moondream2. For other model families set
     `handler_name` in config to one of:
+      - "moondream" → MoondreamChatHandler  (default)
       - "qwen2.5vl" → Qwen25VLChatHandler
       - "llava15"/"llava16" → Llava15ChatHandler / Llava16ChatHandler
-      - "moondream" → MoondreamChatHandler
       - "minicpmv" → MiniCPMv26ChatHandler
       - "nanollava" → NanollavaChatHandler
     """
@@ -179,7 +179,7 @@ def resolve_vlm_engine(
     """Resolve a VLM engine by name or auto-detect first available.
 
     Auto-detect order: LlamaCppVLMEngine (only MVP engine). Future:
-    OllamaVLMEngine alternative, ClaudeVisionEngine fallback.
+    LlamaServerVLMEngine alternative, ClaudeVisionEngine fallback.
     """
     name_map: dict[str, type[LlamaCppVLMEngine]] = {
         "llamacpp": LlamaCppVLMEngine,


### PR DESCRIPTION
## Summary

Four stale references survived the #91/#92/#93/#94/#97 wave. Found via repo-wide grep for `Ollama`, `Qwen2.5-VL`-as-default, hardcoded HF URLs, and abetlen wheel URLs. Topical commit covers all four — comments and docs only, no code-path changes.

| File:line | Drift | Fix |
|---|---|---|
| `src/cc_vlm/engine.py:60` | docstring *"Default handler is Qwen2.5-VL"* | → Moondream2 + reorder handler list (moondream first) |
| `src/cc_vlm/engine.py:182` | resolver docstring `OllamaVLMEngine alternative` | → `LlamaServerVLMEngine alternative` |
| `skills/see/SKILL.md:71` | *"rationale for picking llama-cpp-python over Ollama"* + wrong anchor `#vlm-token-budget` | generalized to *"over external daemons (Ollama, llama-server)"* + corrected anchor `#vlm-engine-comparison` |
| `skills/see/SKILL.md:93` | follow-ups list mentions *"Ollama backend"* | → *"`LlamaServerVLMEngine` HTTP backend"* |

## Drift scan negatives (verified, not drift)

- Historical `CHANGELOG.md` entries — intentionally unchanged
- `docs/adr/0003-vlm-screen-sharing.md` mentioning Qwen2.5-VL — ADR is immutable historical record per project convention
- All other `Qwen2.5-VL` mentions correctly reference the alt path (alt config, alt Makefile target, tests asserting alt path)
- Makefile HF URLs — single source of truth by design (centralized per #91)
- `_PIPER_HF_BASE` in `cc_tts/engine.py` — unrelated TTS path

## Verification

- [x] `pytest tests/test_vlm_engine.py` → 25/25 pass
- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

Generated with Claude <noreply@anthropic.com>
