### PR TITLE
docs: introduce docs/landscape.md — engine/model evaluation matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,22 @@
 
 ### Added
 
-- docs: `docs/UserStory.md` — three end-to-end flows (Voice Loop, screen-content-to-Claude, hotkey-stopped playback) and three personas (#83)
-- feat(make): `setup_see` and `setup_see_qwen25` Makefile targets — install `--extra see`, download the GGUF + mmproj into `~/.cache/cc-voice/models/`, detect host hardware and print the matching `llama-cpp-python` install command, then print the `[vlm]` snippet for `.cc-voice.toml` (#91)
-- test(make): `tests/test_makefile_targets.py` smoke-tests the new setup_see targets via `make -n` dry-run (#91)
+- docs: `docs/UserStory.md` — three end-to-end flows + personas (#83)
+- feat(vlm): `make setup_see` / `setup_see_qwen25` targets — guided VLM install with hardware detection; download URLs centralized in Makefile vars (#91)
+- docs: `docs/landscape.md` — engine/model evaluation matrix (single source of truth for shipped / deferred / rejected per subsystem)
 
 ### Changed
 
-- docs: dedupe config schema — `.cc-voice.example.toml` is the single source of truth for `.cc-voice.toml` fields and `CC_*` env overrides; README and `skills/*/SKILL.md` link to it instead of embedding partial copies. README slimmed 185 → 73 lines; SKILL.md sum 275 → 182 lines (#83, closes #60)
-- chore: slim `.cc-voice.toml` from 47 to 8 lines — removes the duplicated full schema; only fields that override the example defaults remain. Behavior unchanged; `.cc-voice.example.toml` is now the canonical schema reference (#87, refs #60)
-- docs(roadmap): mark v0.5.0/v0.6.0 as shipped; drop closed #29/#33/#34 from "Tracked" (#81)
-- feat(vlm): default VLM handler flips from `qwen2.5vl` to `moondream` — Moondream2 is sub-1 GB Q4 GGUF, Apache 2.0, fastest CPU path; Qwen2.5-VL handler stays available as alt (#91)
-- docs(vlm): `skills/see/SKILL.md` install section collapsed from ~22 lines to ~6; all hardcoded Hugging Face + abetlen wheel-index URLs moved to `Makefile` variables — single source of truth. `docs/UserStory.md` Flow B and `docs/architecture.md` handler table updated to reflect Moondream2 default (#91)
-- docs(readme): Features bullet flipped to Moondream2 (Qwen2.5-VL noted as alt) (#93)
-- docs(skills): drop redundant `# /listen|/see|/speak` H1 from each `skills/*/SKILL.md` body — title is already in YAML frontmatter `name:`; removes drift surface (#94)
+- feat(vlm): default VLM handler flips `qwen2.5vl` → `moondream` (Qwen2.5-VL stays available as alt) (#91)
+- docs: dedupe config schema — `.cc-voice.example.toml` is canonical; README + `skills/*/SKILL.md` link to it (#83, #87, closes #60)
+- docs(roadmap): mark v0.5.0/v0.6.0 as shipped; trim closed-issue noise (#81)
+- docs(skills): drop redundant H1 from each `skills/*/SKILL.md` — title lives in YAML frontmatter (#94)
 
 ### Fixed
 
-- fix(vlm): replace inline Hugging Face URL in "No VLM engine available" `RuntimeError` with `make setup_see` pointer (#91)
-- fix(config): wrap TTS keys in `[tts]` section in `.cc-voice.example.toml` — top-level TTS keys were silently ignored by the `load_toml_section("tts")` loader (#83)
-- fix(readme): Link Checker badge URL pointed at non-existent `links-fail-fast.yaml` workflow — repointed at `lint-md-links.yml` (#93)
-- chore(changelog): merge duplicate `### Fixed` subsections under `[Unreleased]` to satisfy markdownlint MD024 (#93)
+- fix(vlm): "No VLM engine available" `RuntimeError` points at `make setup_see` instead of an inline HF URL (#91)
+- fix(config): wrap TTS keys in `[tts]` section in `.cc-voice.example.toml` (#83)
+- fix(readme): Link Checker badge URL repointed at `lint-md-links.yml` (was 404 on missing workflow) (#93)
 
 ### Removed
 
@@ -31,7 +27,7 @@
 
 ### Tests
 
-- test(speak): add `--stop` and `--stream` coverage — 7 new tests (3 → 10 total) covering pidfile lifecycle, SIGTERM dispatch to recorded pgid, ProcessLookupError graceful handling, and streaming flag routing through `edge_stream.speak_streaming` (#88, closes #56 line item)
+- test(speak): `--stop` and `--stream` coverage — pidfile lifecycle, SIGTERM dispatch, streaming flag routing (#88, closes #56 line item)
 
 ### Internal
 

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -1,0 +1,144 @@
+# Engine & model landscape
+
+What we evaluated for cc-voice's three subsystems — what shipped, what's
+deferred, what's rejected and why. This is the **single source of truth
+for engine/model decisions**; `docs/architecture.md` describes the
+shipped engines in detail and `docs/roadmap/v0.5.x.md` tracks
+time-bound work.
+
+When a new engine or framework is researched, record the verdict here
+so future sessions see "verified, here's why" and skip re-research.
+
+## Hard constraints
+
+Every candidate is judged against these. Anything that violates one is
+a hard reject unless the violation is fixed upstream.
+
+- **Local-first** — runs on the user's machine; no required cloud calls.
+  Cloud engines (e.g. edge-tts) tolerated only as opt-in alternatives.
+- **CPU-feasible** — works without a GPU; quantization (GGUF, ONNX
+  INT8) preferred.
+- **License: Apache 2.0 / MIT / BSD strongly preferred.** Anything with a
+  revenue cap, BSL, or "research-only" clause is rejected unless it
+  changes upstream.
+- **Pluggable Protocol fit** — slots in as an additional engine class
+  implementing the subsystem's `Protocol`; no daemon ownership of the
+  process lifecycle, no full-framework adoption.
+- **Half-duplex by design** — TTS and STT run sequentially; full-duplex
+  frameworks are out of scope unless they contribute a single-component
+  engine.
+
+## TTS
+
+### Shipped
+
+See [`docs/architecture.md` § TTS engine comparison](architecture.md#tts-engine-comparison)
+for full details (latency, deps, notes).
+
+| handler | role | license |
+|---|---|---|
+| `kokoro` (auto-detect default) | best local quality | Apache 2.0 |
+| `edge-tts` | high quality, requires internet | MIT (client); cloud service |
+| `piper` | neural VITS, ~60 MB voice models | MIT |
+| `espeak` | basic, zero-config fallback | GPL-3.0 (binary; cc-voice invokes via subprocess) |
+
+### Tracked
+
+- **#30** — `feat(tts): Kokoro voice blending via embedding math`. The
+  only supported custom-voice path for Kokoro (StyleTTS2 → not
+  fine-tunable). ~50 LOC + tests, shippable today.
+
+### Considered / deferred
+
+| Candidate | Status | Notes |
+|---|---|---|
+| **Orpheus-TTS via `llama-cpp-python`** | deferred | Enables Unsloth fine-tune path for domain-adapted TTS. Gate on actual user demand for fine-tuned custom voices (not pressing today). ~100 LOC + reuses the `llama-cpp-python` dep already pulled in by `cc_vlm`. |
+
+### Rejected
+
+| Candidate | Why not |
+|---|---|
+| **Unsloth → Kokoro fine-tune → GGUF** | Architecturally impossible: Kokoro is StyleTTS2 (not transformers-compatible), not in Unsloth's supported model list, and has no official fine-tune script. The correct custom-voice path is embedding blending — tracked as #30. |
+| **k2-fsa/omnivoice** | Apache 2.0 header but model card adds "academic research purposes only" disclaimer; GPU/MPS-only inference path documented (no CPU/ONNX/GGUF). Existing TTS engines (kokoro/piper/espeak) all run CPU-only. Revisit if a clean Apache export with quantized CPU path ships. |
+
+## STT
+
+### Shipped
+
+See [`docs/architecture.md` § STT engine comparison](architecture.md#stt-engine-comparison)
+for full details.
+
+| handler | role | license |
+|---|---|---|
+| `moonshine` (auto-detect default) | English, 27 M params, ONNX | MIT |
+| `vosk` | 20+ languages, ~50 MB models | Apache 2.0 |
+
+### Tracked
+
+- **#31** — `feat(stt): Whisper engine via faster-whisper` — domain
+  fine-tunes (medical, legal, accented speech) via PEFT/LoRA workflow.
+  CC-BY-4.0 / MIT.
+- **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr` —
+  multilingual, CC-BY-4.0, CPU-friendly INT8 ONNX. Validated by NVIDIA
+  NeMo as their default STT.
+
+### Considered / deferred
+
+(None currently.)
+
+### Rejected
+
+(None currently — no STT engines have been formally rejected.)
+
+## VLM
+
+### Shipped
+
+See [`docs/architecture.md` § VLM engine comparison](architecture.md#vlm-engine-comparison)
+and the supported-handlers table for full details.
+
+| handler | role | license |
+|---|---|---|
+| `moondream` (default) | Moondream2, ~0.9 GB Q4, fastest CPU path | Apache 2.0 |
+| `qwen2.5vl` | Qwen2.5-VL-2B/3B/7B, richer output, ~1.6 GB Q4 | Apache 2.0 |
+| `llava15` / `llava16` | LLaVA 1.5 / 1.6 | Apache 2.0 |
+| `minicpmv` | MiniCPM-V 2.6 | Apache 2.0 |
+| `nanollava` | NanoLLaVA | Apache 2.0 |
+
+All shipped via the single `LlamaCppVLMEngine` class in
+`src/cc_vlm/engine.py`, dispatched on `handler_name`.
+
+### Considered / deferred
+
+To be filed as issues; placeholder list for now.
+
+| Candidate | Status | Notes |
+|---|---|---|
+| **`LlamaServerVLMEngine` HTTP backend** | deferred (Phase 2) | Same `llama.cpp` binary as the in-process path — adds an HTTP-server engine class so users can run any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs. Unlocks SmolVLM2-2.2B and Qwen3-VL-2B on the day llama.cpp supports them. Ollama considered and rejected (extra daemon family, Ollama-as-dependency). |
+| **`Qwen3VLChatHandler` for in-process backend** | deferred (Phase 3) | Blocked on [`abetlen/llama-cpp-python` #2080](https://github.com/abetlen/llama-cpp-python/issues/2080). Add `"qwen3vl"` to `_HANDLER_MAP` once the upstream class lands. Until then, `LlamaServerVLMEngine` (above) is the unblock path. |
+| **`available()` hardening for handler-class-mismatch** | deferred | `engine.py:available()` only checks `handler_name in _HANDLER_MAP`, not whether the class actually exists in the installed `llama_cpp.llama_chat_format` module. Latent footgun for any new handler we add. |
+| **`ClaudeVisionEngine` fallback** | deferred (per ADR-0003 Tier 1) | Returns image path reference for Claude's built-in vision instead of running a local VLM. ~1,600 tokens/call (vs ~120 for local VLM). Opt-in `--vision` flag. |
+| **SmolVLM2-2.2B** | deferred via `LlamaServerVLMEngine` | Apache 2.0, ~1.1 GB Q4, designed for on-device CPU. No `SmolVLMChatHandler` in `abetlen/llama-cpp-python`; reachable today only via `llama-server`. |
+
+### Rejected
+
+| Candidate | Why not |
+|---|---|
+| **inferrs** as VLM backend | Text-LLM only; no vision support anywhere in README/features. Verified via WebFetch. |
+| **DPT-2 Mini** (Landing AI) | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-voice's local-first positioning. |
+| **LFM2-VL-3B** (Liquid AI) | Two blockers: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and LFM Open License v1.0 imposes a $10M revenue cap (not Apache 2.0). Revisit only if the bug closes AND the license relaxes. |
+| **Moondream3 (preview)** | Business Source License 1.1 — not OSI-compliant; "Additional Use Grant (No Third-Party Service)" clause forbids hosted-service use. No GGUF; transformers-only runtime. |
+| **Florence-2** (Microsoft) | Encoder-decoder architecture; not representable in GGUF / not supported by llama.cpp. Would require a parallel runtime (`transformers` or ONNX) and a different `describe()` calling convention (task-based, not chat). Out of scope for the current Protocol. |
+| **Apple FastVLM** | Apple Silicon-optimized; primary runtime is MLX, not llama.cpp. No `abetlen/llama-cpp-python` handler. Worth revisiting only if cc-voice adds an `MLXVLMEngine` backend specifically for macOS users. |
+| **Phi-4-Multimodal** (Microsoft) | ~14B params; ~9-10 GB at Q4; 12 GB GPU recommended. Too heavy for CPU-only deployment. |
+
+## Cross-subsystem frameworks
+
+### Rejected
+
+These offered to *replace* cc-voice's architecture rather than slot into a single subsystem.
+
+| Candidate | Why not |
+|---|---|
+| **PersonaPlex** | Scope mismatch — replaces Claude Code's LLM entirely. cc-voice's value prop is "Claude Code does the thinking". Only useful as a future-direction note for the half-duplex → full-duplex frontier (see roadmap "Deferred ideas"). |
+| **TEN-framework** (Agora) | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-voice hard constraint violated. |

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -9,7 +9,8 @@ development lines. **Actionable items are filed as GitHub issues** with the
 
 - **Actionable work**: [GitHub issues](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 - **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
-- **Deferred ideas + rejected paths**: this file
+- **Engine / model / framework evaluations** (shipped, deferred, rejected): [`docs/landscape.md`](../landscape.md)
+- **Deferred tooling/process ideas + rejected non-engine paths**: this file
 - **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-voice-plugin-prototype/memory/`
 
 ## Recently shipped
@@ -41,10 +42,8 @@ filing noise in the tracker.
 
 ### Engines
 
-- **Orpheus-TTS engine via llama-cpp-python** — enables Unsloth fine-tune
-  path for domain-adapted TTS. Gate on actual user demand for fine-tuned
-  custom voices (not a pressing need today). ~100 LOC + an already-present
-  `llama-cpp-python` dep from `cc_vlm`.
+Engine candidates moved to [`docs/landscape.md`](../landscape.md) — see
+the per-subsystem "Considered / deferred" tables.
 
 ### Tooling / build
 
@@ -77,23 +76,17 @@ filing noise in the tracker.
 
 ## Rejected directions — do NOT reconsider without new evidence
 
-These were researched and decided against during 0.4.x hardening. Preserved
-here to prevent re-research in future sessions.
+Tooling / process rejections only. **Engine / model / framework
+rejections live in [`docs/landscape.md`](../landscape.md)** under each
+subsystem's "Rejected" section.
 
 | Item | Why not |
 |---|---|
-| **inferrs** as VLM backend | Text-LLM only; no vision support anywhere in README/features. Verified via WebFetch. |
-| **Unsloth → Kokoro fine-tune → GGUF** | Architecturally impossible: Kokoro is StyleTTS2 (not transformers-compatible), not in Unsloth's supported model list, and has no official fine-tune script. The correct custom-voice path is **embedding blending** — tracked as #30. |
-| **DPT-2 Mini (Landing AI)** | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-voice's local-first positioning. |
 | **TurboQuant-GPU** (DevTechJr) | KV cache compression for text LLMs; NVIDIA-only; no VLM/audio support. Scope mismatch. |
 | **caveman as plugin** | Real savings are 13-21% per independent benchmark (not the viral 65-75% claim). Redundant with `core-principles.md` + `rtk` already in place. A 6-line prompt matches the full plugin's effect. |
 | **Claude Code router as cc-voice dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-voice's audio/vision pipeline is unaffected by backend routing. |
-| **PersonaPlex adoption** | Scope mismatch — replaces Claude Code's LLM entirely. cc-voice's value prop is "Claude Code does the thinking". Only useful as a future-direction note (deferred idea above). |
 | **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-voice doesn't need to re-document external tools. |
 | **`context-mode`** deep research | Unresearched, not urgent. Revisit only if `rtk`'s command-output compression proves insufficient. |
-| **LFM2-VL-3B** (Liquid AI) | Two blockers: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and LFM Open License v1.0 imposes a $10M revenue cap (not Apache 2.0). Revisit only if the bug closes AND the license relaxes. |
-| **k2-fsa/omnivoice** as TTS engine | Apache 2.0 header but model card adds "academic research purposes only" disclaimer; GPU/MPS-only inference path documented (no CPU/ONNX/GGUF). Existing TTS engines (kokoro/piper/espeak) all run CPU-only. Revisit if a clean Apache export with quantized CPU path ships. |
-| **TEN-framework** (Agora) as cc-voice base | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-voice hard constraint violated. |
 
 ## Process notes
 


### PR DESCRIPTION
## Summary

Per the option-(c) decision: introduce `docs/landscape.md` as the single source of truth for engine/model evaluations, and trim `docs/roadmap/v0.5.x.md` to time-bound work plus tooling/process rejections.

Three topical commits:

1. **`docs(landscape):`** — new `docs/landscape.md` with per-subsystem (TTS / STT / VLM / cross-subsystem frameworks) tables for shipped, tracked, considered/deferred, rejected. Top-level "Hard constraints" section codifies the local-first / CPU-feasible / Apache-license / Protocol-fit / half-duplex bar.
2. **`docs(roadmap):`** — move all engine/model/framework rows out of "Rejected directions" and the "Engines" subsection of "Deferred ideas"; replace with pointers to landscape.md. Roadmap "Source of truth" updated to surface landscape.md.
3. **`docs(changelog):`** — condense `[Unreleased]` from ~17 lines to ~13 by collapsing multi-line per-PR entries (notably #91 5→3, #93 4→1) to one essential line per user-facing change.

## Doc-hierarchy boundary after this PR

| File | Owns |
|---|---|
| `docs/architecture.md` | currently-shipped engines + how they work (latency, deps, perf) |
| `docs/landscape.md` | per-subsystem evaluation matrix: shipped / tracked / considered / rejected with reasons |
| `docs/roadmap/v0.5.x.md` | time-bound work — tracked issues, *actionable* deferred, recently-shipped retrospective; tooling/process rejections only |
| `docs/adr/` | architectural decisions (immutable) |

## Verification

- [x] `make lint_md` → clean
- [x] `make lint_links` → 20/20 OK

Generated with Claude <noreply@anthropic.com>
