### PR TITLE
ci: pin actions to full SHA + grant issues:write to lint workflow

### DIFF
--- a/.github/workflows/bump-my-version.yaml
+++ b/.github/workflows/bump-my-version.yaml
@@ -25,7 +25,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Bump version
         id: bump
-        uses: callowayproject/bump-my-version@0.29.0
+        uses: callowayproject/bump-my-version@e6ecdc3e573698766cd6c2112faeda50bcc2e56a  # 1.3.0
         env:
           BUMPVERSION_TAG: "true"
         with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,19 +18,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
       with:
         languages: python
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
 
     - name: Perform CodeQL Analysis
       id: analyze
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
       with:
         output: sarif-results
 

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write  # required by reusable workflow's notify job (gated on opt-in input; declared so caller permits the subset)
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

Two CI failures rooted out:

### 1. `Set up job` failure on every CodeQL run since 2026-05-07 ~23:00 UTC

The repo enabled the **"Require actions to be pinned to a full-length commit SHA"** ruleset. Every workflow using major-tag references (`@v4`, `@0.29.0`) failed at startup. Pin to latest stable releases:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) |
| `github/codeql-action/{init,autobuild,analyze}` | `@v4` | `68bde559dea0fdcac2102bfdf6230c5f70eb485e` (v4.35.4) |
| `callowayproject/bump-my-version` | `@0.29.0` | `e6ecdc3e573698766cd6c2112faeda50bcc2e56a` (1.3.0) |

`bump-my-version` 1.3.0 also matches `pyproject.toml` dev dep `bump-my-version>=1.3.0`.

### 2. `Lint MD and Links` `startup_failure` on every run since 2026-05-06 23:32 UTC

The reusable workflow at `qte77/.github/.../lint-md-links.yml` has a `notify` job declaring `permissions: issues: write` at the job level (opt-in via `inputs.notify_on_failure`, default false). GitHub statically validates that called workflows can't claim more permissions than the caller grants — even if the gated job would skip. The caller declared only `contents: read`. Add `issues: write` to top-level caller permissions.

The notify job stays opt-in — no-op until a caller passes `notify_on_failure: true`.

## Why this PR is needed before #99

PR #99 (`docs/landscape`) is blocked because its CodeQL run fails for reason 1. Once this PR lands, #99 rebases onto new main and CI runs against the SHA-pinned workflows.

## Test plan

- [ ] CodeQL workflow on this branch completes (no `Set up job` failure)
- [ ] Lint MD and Links workflow on this branch starts (no `startup_failure`)

Generated with Claude <noreply@anthropic.com>
