### PR TITLE
chore: rename cc-voice → cc-senses-bridge

### DIFF
--- a/.cc-senses.example.toml
+++ b/.cc-senses.example.toml
@@ -1,5 +1,5 @@
-# CC-Voice configuration
-# Copy to .cc-voice.toml and adjust as needed.
+# cc-senses-bridge configuration
+# Copy to .cc-senses.toml and adjust as needed.
 #
 # Handler-name values for [vlm] are listed in docs/architecture.md.
 

--- a/.cc-senses.toml
+++ b/.cc-senses.toml
@@ -1,0 +1,46 @@
+# cc-senses-bridge configuration
+# Copy to .cc-senses.toml and adjust as needed.
+#
+# Handler-name values for [vlm] are listed in docs/architecture.md.
+
+# TTS settings (env overrides: CC_TTS_ENGINE, CC_TTS_VOICE, CC_TTS_SPEED,
+# CC_TTS_AUTO_READ, CC_TTS_MAX_CHARS, CC_TTS_PLAYER)
+[tts]
+engine = "auto"              # "kokoro" | "piper" | "espeak" | "auto"
+voice = "en_US-amy-medium"   # Engine-specific voice name
+speed = 1.0                  # Playback speed multiplier
+auto_read = false            # Speak every Claude response via Stop hook
+max_chars = 2000             # Truncate input text beyond this limit
+player = "auto"              # "mpv" | "ffplay" | "aplay" | "auto"
+
+# STT settings (env overrides: CC_STT_ENGINE, CC_STT_LANGUAGE,
+# CC_STT_WAKE_WORD, CC_STT_MIC_DEVICE, CC_STT_AUTO_LISTEN,
+# CC_STT_STRIP_FILLERS, CC_STT_INTENT_MATCH, CC_STT_MAX_WORDS)
+[stt]
+engine = "auto"              # "moonshine" | "vosk" | "auto"
+language = "en"
+wake_word = "hey_claude"
+mic_device = "default"
+auto_listen = false          # Start listening on session start
+strip_fillers = true         # Remove "um", "uh", "like" before sending to LLM
+intent_match = true          # Match common commands locally (skip LLM)
+max_words = 200              # Hard word cap on transcriptions
+
+# VLM settings (env overrides: CC_VLM_ENGINE, CC_VLM_MODEL_PATH,
+# CC_VLM_MMPROJ_PATH, CC_VLM_HANDLER_NAME, CC_VLM_N_CTX,
+# CC_VLM_N_GPU_LAYERS, CC_VLM_MAX_TOKENS, CC_VLM_MAX_DIMENSION,
+# CC_VLM_JPEG_QUALITY, CC_VLM_TEMPLATE, CC_VLM_CACHE_SIZE)
+[vlm]
+engine = "auto"              # "auto" | "llamacpp"
+model_path = ""              # Absolute path to .gguf vision model (set by `make setup_see`)
+mmproj_path = ""             # Absolute path to mmproj (CLIP projector) .gguf
+handler_name = "moondream"   # Default: Moondream2 (~0.9 GB Q4, fastest CPU path)
+                             # Alt: "qwen2.5vl" (~1.6 GB, richer output) via `make setup_see_qwen25`
+                             # Other handlers — see docs/architecture.md
+n_ctx = 4096                 # Context window
+n_gpu_layers = 0             # 0 = CPU only, -1 = all layers to GPU
+max_tokens = 256             # Max VLM response tokens
+max_dimension = 768          # Resize longest edge before VLM (tokens ∝ dimension²)
+jpeg_quality = 85
+template = "generic"         # Default template if --template not passed
+cache_size = 32              # Per-invocation LRU entries

--- a/.cc-voice.toml
+++ b/.cc-voice.toml
@@ -1,8 +1,0 @@
-# Project-recommended dev defaults for cc-voice.
-# See .cc-voice.example.toml for the full schema, defaults, and env overrides.
-# This file lists only fields that override the example defaults.
-
-[tts]
-engine = "edge"      # example default: "auto"
-voice = "af_sarah"   # example default: "en_US-amy-medium"
-auto_read = true     # example default: false

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,18 @@
 {
-  "name": "cc-voice",
+  "name": "cc-senses-bridge",
   "owner": {
     "name": "qte77"
   },
   "metadata": {
-    "description": "End-to-end voice plugin for Claude Code — TTS output and STT input",
-    "version": "0.7.0"
+    "description": "Local multimodal I/O bridge for Claude Code — voice and vision",
+    "version": "0.8.0"
   },
   "plugins": [
     {
-      "name": "cc-voice",
+      "name": "cc-senses-bridge",
       "source": "./",
-      "description": "TTS via PTY proxy and Stop hook (/speak), STT via Moonshine/Vosk (/listen)",
-      "version": "0.7.0"
+      "description": "Local multimodal I/O — /speak (TTS), /listen (STT), /see (VLM)",
+      "version": "0.8.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "cc-voice",
-  "version": "0.7.0",
-  "description": "End-to-end voice for Claude Code. TTS output via /speak, STT input via /listen.",
+  "name": "cc-senses-bridge",
+  "version": "0.8.0",
+  "description": "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see).",
   "author": {
     "name": "qte77"
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,7 @@
     "commit-helper@qte77-claude-code-utils": true,
     "codebase-tools@qte77-claude-code-utils": true,
     "cc-meta@qte77-claude-code-utils": true,
-    "cc-voice@cc-voice": true,
+    "cc-senses-bridge@cc-senses-bridge": true,
     "security-audit@qte77-claude-code-utils": true,
     "makefile-core@qte77-claude-code-utils": true,
     "docs-generator@qte77-claude-code-utils": true,
@@ -79,10 +79,10 @@
         "repo": "qte77/claude-code-plugins"
       }
     },
-    "cc-voice": {
+    "cc-senses-bridge": {
       "source": {
         "source": "github",
-        "repo": "qte77/cc-voice-plugin-prototype"
+        "repo": "qte77/cc-senses-bridge"
       }
     }
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Worker 2 (Docs): Update SKILL.md and README with --format flag docs. Files: skil
 - **Skills**: `skills/speak/SKILL.md`, `skills/listen/SKILL.md`, `skills/see/SKILL.md`
 - **ADRs**: `docs/adr/0001-tts-delivery-modes.md`, `docs/adr/0002-stt-engine-selection.md`, `docs/adr/0003-vlm-screen-sharing.md`
 - **Roadmap**: `docs/roadmap/v0.5.x.md`
-- **Config**: `.cc-voice.toml` (TOML + env overrides)
+- **Config**: `.cc-senses.toml` (TOML + env overrides)
 - **Learnings**: `AGENT_LEARNINGS.md`
 
 ## Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-12
+
+### Changed
+
+- chore: rename project `cc-voice` → `cc-senses-bridge` to reflect multimodal scope (TTS + STT + VLM). Config file renamed `.cc-voice.toml` → `.cc-senses.toml`; cache directory `~/.cache/cc-voice/` → `~/.cache/cc-senses-bridge/`; plugin slug renamed across `plugin.json`, `marketplace.json`, install commands, and docs. Python module names (`cc_tts`, `cc_stt`, `cc_vlm`, `cc_voice_common`) kept as-is to avoid import churn.
+
+### Migration notes
+
+- Move existing `.cc-voice.toml` to `.cc-senses.toml`
+- Move cached VLM models from `~/.cache/cc-voice/models/` to `~/.cache/cc-senses-bridge/models/`, or re-run `make setup_see`
+- Reinstall plugin: `make plugin_uninstall && make plugin_install_local`
+
 ## [0.7.0] - 2026-05-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # -- VLM model + llama-cpp-python wheel URLs (single source of truth) --
 # Update these vars when bumping recommended models or wheel index URLs.
-VLM_MODELS_DIR          := $(HOME)/.cache/cc-voice/models
+VLM_MODELS_DIR          := $(HOME)/.cache/cc-senses-bridge/models
 VLM_MOONDREAM_MODEL_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-text-model-f16_ct-q4_0.gguf
 VLM_MOONDREAM_MMPROJ_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-mmproj-f16.gguf
 VLM_QWEN25_MODEL_URL    := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
@@ -30,7 +30,7 @@ LLAMA_CPP_INDEX_CUDA124 := https://abetlen.github.io/llama-cpp-python/whl/cu124
 # MARK: SETUP
 
 
-setup: ## Install cc-voice package (frozen lockfile)
+setup: ## Install cc-senses-bridge package (frozen lockfile)
 	uv sync --frozen
 
 setup_dev: ## Install with dev + test deps + all extras
@@ -85,7 +85,7 @@ setup_see: ## Install /see deps + download Moondream2 (recommended default VLM)
 		echo "    uv pip install llama-cpp-python --extra-index-url $(LLAMA_CPP_INDEX_CPU)    # CPU"
 	fi
 	echo ""
-	echo "  Then add this to .cc-voice.toml:"
+	echo "  Then add this to .cc-senses.toml:"
 	echo ""
 	echo "    [vlm]"
 	echo "    model_path = \"$$model\""
@@ -110,7 +110,7 @@ setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (alt VLM, richer
 		echo "Qwen2.5-VL-3B mmproj already present — skipping."
 	fi
 	echo ""
-	echo "  Then add this to .cc-voice.toml:"
+	echo "  Then add this to .cc-senses.toml:"
 	echo ""
 	echo "    [vlm]"
 	echo "    model_path = \"$$model\""
@@ -119,7 +119,7 @@ setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (alt VLM, richer
 
 setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no dev tools)
 	@echo ""
-	@echo "  ✓ cc-voice ready for /speak via Kokoro."
+	@echo "  ✓ cc-senses-bridge ready for /speak via Kokoro."
 	@echo "  Try: cc-tts 'hello from claude code'"
 	@echo ""
 	@echo "  Opt-in for more:"
@@ -130,16 +130,16 @@ setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no
 
 setup_all: setup_dev setup_espeak setup_piper setup_kokoro setup_stt ## Developer happy path: dev tools + all TTS + STT
 	@echo ""
-	@echo "✓ cc-voice ready."
+	@echo "✓ cc-senses-bridge ready."
 	@echo "  Try: cc-tts 'hello from claude code'"
 	@echo "  Then in Claude Code: /speak --toggle"
 
 clean: ## Remove venv + caches (preserves downloaded TTS/STT/VLM models)
 	rm -rf .venv .pytest_cache .ruff_cache .coverage
 
-clean_models: ## Remove downloaded VLM models (~/.cache/cc-voice/models/)
-	@echo "Removing $$HOME/.cache/cc-voice/models/ ..."
-	@rm -rf $$HOME/.cache/cc-voice/models
+clean_models: ## Remove downloaded VLM models (~/.cache/cc-senses-bridge/models/)
+	@echo "Removing $$HOME/.cache/cc-senses-bridge/models/ ..."
+	@rm -rf $$HOME/.cache/cc-senses-bridge/models
 
 clean_see_artifacts: ## Remove /tmp JPEG artifacts produced by cc_vlm --save-only
 	@echo "Removing /tmp JPEG captures ..."
@@ -147,7 +147,7 @@ clean_see_artifacts: ## Remove /tmp JPEG artifacts produced by cc_vlm --save-onl
 
 clean_all: clean clean_models clean_see_artifacts ## Remove venv + caches + models + temp artifacts (full local reset)
 	@echo ""
-	@echo "  All cc-voice local artifacts removed."
+	@echo "  All cc-senses-bridge local artifacts removed."
 	@echo "  For Claude Code plugin removal also run: make plugin_uninstall"
 
 
@@ -252,18 +252,18 @@ smoke: smoke_imports smoke_cli test ## Full smoke: imports + CLIs + test suite
 plugin_validate: ## Validate the local plugin manifest without installing
 	claude plugin validate .
 
-plugin_install_local: ## Install cc-voice from the local working tree (project scope)
+plugin_install_local: ## Install cc-senses-bridge from the local working tree (project scope)
 	@echo "Registering local repo as a project-scope marketplace ..."
 	claude plugin marketplace add "$(CURDIR)" --scope project
-	@echo "Installing cc-voice from local marketplace ..."
-	claude plugin install cc-voice@cc-voice --scope project
+	@echo "Installing cc-senses-bridge from local marketplace ..."
+	claude plugin install cc-senses-bridge@cc-senses-bridge --scope project
 	@echo ""
 	@echo "  ✓ plugin installed (project scope). Verify: make plugin_list"
 	@echo "  Then: make run_cc  (try /speak /listen /see in the session)"
 
-plugin_uninstall: ## Remove cc-voice plugin + local marketplace
-	-claude plugin uninstall cc-voice
-	-claude plugin marketplace remove cc-voice --scope project
+plugin_uninstall: ## Remove cc-senses-bridge plugin + local marketplace
+	-claude plugin uninstall cc-senses-bridge
+	-claude plugin marketplace remove cc-senses-bridge --scope project
 
 plugin_list: ## Show installed Claude Code plugins
 	claude plugin list
@@ -284,8 +284,8 @@ run_voice_stream_json: ## Speak Claude response via stream-json (non-interactive
 run_repl: ## Interactive REPL with stream-json TTS (no Ink UI, sandbox-safe)
 	uv run cc-tts-repl
 
-reinstall_plugin: ## Force-reinstall cc-voice plugin (busts stale cache)
-	claude plugin install cc-voice@cc-voice --force
+reinstall_plugin: ## Force-reinstall cc-senses-bridge plugin (busts stale cache)
+	claude plugin install cc-senses-bridge@cc-senses-bridge --force
 
 
 # MARK: VERSION

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-cc-voice
+cc-senses-bridge
 Copyright 2026 qte77
 
 This product includes software developed by qte77.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# cc-voice (prototype)
+# cc-senses-bridge
 
-> **Status: Prototype** — end-to-end voice for Claude Code. TTS output via PTY proxy, STT input module scaffolded (config, engine, mic, VAD, PTY injection). Not production-ready.
+> Local multimodal I/O bridge for Claude Code — TTS output via `/speak`, STT input via `/listen`, screen-vision via `/see`.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.7.0-58f4c2.svg)
-[![CodeQL](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/codeql.yaml)
-[![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype/badge)](https://www.codefactor.io/repository/github/qte77/cc-voice-plugin-prototype)
-[![Dependabot](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/dependabot/dependabot-updates)
-[![Lint MD and Links](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/cc-voice-plugin-prototype/actions/workflows/lint-md-links.yml)
+![Version](https://img.shields.io/badge/version-0.8.0-58f4c2.svg)
+[![CodeQL](https://github.com/qte77/cc-senses-bridge/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/codeql.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-senses-bridge/badge)](https://www.codefactor.io/repository/github/qte77/cc-senses-bridge)
+[![Dependabot](https://github.com/qte77/cc-senses-bridge/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/dependabot/dependabot-updates)
+[![Lint MD and Links](https://github.com/qte77/cc-senses-bridge/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/lint-md-links.yml)
 
-End-to-end voice plugin for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk, VLM ingests the screen and feeds it as text into Claude's context for Claude to act on.
+Local multimodal I/O for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk, VLM ingests the screen and feeds it as text into Claude's context for Claude to act on.
 
 ## Features
 
@@ -31,7 +31,7 @@ Session summary generated with three engines for comparison:
 
 ```bash
 make setup_dev      # install package + dev deps
-make setup_tts      # install espeak-ng + mpv (zero-config baseline)
+make setup_espeak   # install espeak-ng + mpv (zero-config baseline)
 make setup_piper    # install Piper (neural)
 make setup_kokoro   # install Kokoro (best local)
 
@@ -41,19 +41,19 @@ cc-tts "Hello"      # one-shot CLI
 
 ## Configuration
 
-Copy [`.cc-voice.example.toml`](.cc-voice.example.toml) to `.cc-voice.toml` and edit. All TTS, STT, and VLM fields plus `CC_*` env-var overrides are documented inline.
+Copy [`.cc-senses.example.toml`](.cc-senses.example.toml) to `.cc-senses.toml` and edit. All TTS, STT, and VLM fields plus `CC_*` env-var overrides are documented inline.
 
 ## CC Plugin
 
 ```bash
-claude plugin install cc-voice@local
+claude plugin install cc-senses-bridge@cc-senses-bridge
 ```
 
 Provides `/speak`, `/listen`, `/see` skills and Stop-hook auto-read.
 
 ## Documentation
 
-- [`.cc-voice.example.toml`](.cc-voice.example.toml) — config schema and env vars
+- [`.cc-senses.example.toml`](.cc-senses.example.toml) — config schema and env vars
 - [Architecture](docs/architecture.md) — pipelines, engines, diagrams, token budgets
 - [User flows](docs/UserStory.md) — personas and end-to-end use cases (incl. hotkey-stop playback)
 - [ADRs](docs/adr/) — decision records (TTS modes, STT engines, VLM screen-sharing)

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -1,7 +1,7 @@
 # User Stories
 
-End-to-end flows showing how cc-voice fits into a real working session.
-For the full configuration schema, see [`.cc-voice.example.toml`](../.cc-voice.example.toml).
+End-to-end flows showing how cc-senses-bridge fits into a real working session.
+For the full configuration schema, see [`.cc-senses.example.toml`](../.cc-senses.example.toml).
 For pipeline and engine details, see [architecture.md](architecture.md).
 
 ## Personas
@@ -26,10 +26,10 @@ Steps:
 1. `/speak --toggle` — enables Stop-hook auto-read so every response
    is spoken once it completes.
 2. `/voice` — enables Claude Code's built-in mic input.
-3. Speak a prompt → Claude transcribes → answers in text → cc-voice
+3. Speak a prompt → Claude transcribes → answers in text → cc-senses-bridge
    reads the answer aloud.
 
-Minimal config (in `.cc-voice.toml`):
+Minimal config (in `.cc-senses.toml`):
 
 ```toml
 auto_read = true
@@ -55,7 +55,7 @@ Two paths exist:
   device to extract a short text summary; ~120 tokens per call. Lower
   fidelity, but cheap enough to use repeatedly.
 
-cc-voice's `/see` uses the local path by default.
+cc-senses-bridge's `/see` uses the local path by default.
 
 Steps:
 
@@ -79,8 +79,8 @@ Minimal config (run `make setup_see` to populate the paths):
 
 ```toml
 [vlm]
-model_path = "/home/USER/.cache/cc-voice/models/moondream2-text-model-f16_ct-q4_0.gguf"
-mmproj_path = "/home/USER/.cache/cc-voice/models/moondream2-mmproj-f16.gguf"
+model_path = "/home/USER/.cache/cc-senses-bridge/models/moondream2-text-model-f16_ct-q4_0.gguf"
+mmproj_path = "/home/USER/.cache/cc-senses-bridge/models/moondream2-mmproj-f16.gguf"
 handler_name = "moondream"
 ```
 
@@ -96,7 +96,7 @@ shell or REPL.
 uv run cc-tts --stop
 ```
 
-Reads the PID file at `~/.cache/cc-voice/speak.pid` and SIGTERMs the
+Reads the PID file at `~/.cache/cc-senses-bridge/speak.pid` and SIGTERMs the
 whole process group. Works for all delivery modes (Stop hook,
 stream-json, PTY proxy) — every mode writes the pidfile on start.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,13 @@
 # Architecture
 
-Single source of truth for cc-voice pipeline and engine details.
+Single source of truth for cc-senses-bridge pipeline and engine details.
 ADRs in `docs/adr/` record decisions; this file records the current design.
 
 ---
 
 ## Overview
 
-cc-voice adds three subsystems to Claude Code:
+cc-senses-bridge adds three subsystems to Claude Code:
 
 | Subsystem | Command | Role |
 |---|---|---|

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -1,6 +1,6 @@
 # Engine & model landscape
 
-What we evaluated for cc-voice's three subsystems — what shipped, what's
+What we evaluated for cc-senses-bridge's three subsystems — what shipped, what's
 deferred, what's rejected and why. This is the **single source of truth
 for engine/model decisions**; `docs/architecture.md` describes the
 shipped engines in detail and `docs/roadmap/v0.5.x.md` tracks
@@ -40,7 +40,7 @@ for full details (latency, deps, notes).
 | `kokoro` (auto-detect default) | best local quality | Apache 2.0 |
 | `edge-tts` | high quality, requires internet | MIT (client); cloud service |
 | `piper` | neural VITS, ~60 MB voice models | MIT |
-| `espeak` | basic, zero-config fallback | GPL-3.0 (binary; cc-voice invokes via subprocess) |
+| `espeak` | basic, zero-config fallback | GPL-3.0 (binary; cc-senses-bridge invokes via subprocess) |
 
 ### Tracked
 
@@ -125,20 +125,20 @@ To be filed as issues; placeholder list for now.
 | Candidate | Why not |
 |---|---|
 | **inferrs** as VLM backend | Text-LLM only; no vision support anywhere in README/features. Verified via WebFetch. |
-| **DPT-2 Mini** (Landing AI) | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-voice's local-first positioning. |
+| **DPT-2 Mini** (Landing AI) | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-senses-bridge's local-first positioning. |
 | **LFM2-VL-3B** (Liquid AI) | Two blockers: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and LFM Open License v1.0 imposes a $10M revenue cap (not Apache 2.0). Revisit only if the bug closes AND the license relaxes. |
 | **Moondream3 (preview)** | Business Source License 1.1 — not OSI-compliant; "Additional Use Grant (No Third-Party Service)" clause forbids hosted-service use. No GGUF; transformers-only runtime. |
 | **Florence-2** (Microsoft) | Encoder-decoder architecture; not representable in GGUF / not supported by llama.cpp. Would require a parallel runtime (`transformers` or ONNX) and a different `describe()` calling convention (task-based, not chat). Out of scope for the current Protocol. |
-| **Apple FastVLM** | Apple Silicon-optimized; primary runtime is MLX, not llama.cpp. No `abetlen/llama-cpp-python` handler. Worth revisiting only if cc-voice adds an `MLXVLMEngine` backend specifically for macOS users. |
+| **Apple FastVLM** | Apple Silicon-optimized; primary runtime is MLX, not llama.cpp. No `abetlen/llama-cpp-python` handler. Worth revisiting only if cc-senses-bridge adds an `MLXVLMEngine` backend specifically for macOS users. |
 | **Phi-4-Multimodal** (Microsoft) | ~14B params; ~9-10 GB at Q4; 12 GB GPU recommended. Too heavy for CPU-only deployment. |
 
 ## Cross-subsystem frameworks
 
 ### Rejected
 
-These offered to *replace* cc-voice's architecture rather than slot into a single subsystem.
+These offered to *replace* cc-senses-bridge's architecture rather than slot into a single subsystem.
 
 | Candidate | Why not |
 |---|---|
-| **PersonaPlex** | Scope mismatch — replaces Claude Code's LLM entirely. cc-voice's value prop is "Claude Code does the thinking". Only useful as a future-direction note for the half-duplex → full-duplex frontier (see roadmap "Deferred ideas"). |
-| **TEN-framework** (Agora) | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-voice hard constraint violated. |
+| **PersonaPlex** | Scope mismatch — replaces Claude Code's LLM entirely. cc-senses-bridge's value prop is "Claude Code does the thinking". Only useful as a future-direction note for the half-duplex → full-duplex frontier (see roadmap "Deferred ideas"). |
+| **TEN-framework** (Agora) | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-senses-bridge hard constraint violated. |

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -1,4 +1,4 @@
-# cc-voice roadmap (v0.5.x → v0.6.x)
+# cc-senses-bridge roadmap (v0.5.x → v0.6.x)
 
 Living document for tracked and deferred work on the 0.5.x and 0.6.x
 development lines. **Actionable items are filed as GitHub issues** with the
@@ -7,11 +7,11 @@ development lines. **Actionable items are filed as GitHub issues** with the
 
 ## Source of truth
 
-- **Actionable work**: [GitHub issues](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
-- **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-voice-plugin-prototype/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- **Actionable work**: [GitHub issues](https://github.com/qte77/cc-senses-bridge/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+- **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-senses-bridge/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 - **Engine / model / framework evaluations** (shipped, deferred, rejected): [`docs/landscape.md`](../landscape.md)
 - **Deferred tooling/process ideas + rejected non-engine paths**: this file
-- **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-voice-plugin-prototype/memory/`
+- **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-senses-bridge/memory/`
 
 ## Recently shipped
 
@@ -60,12 +60,12 @@ the per-subsystem "Considered / deferred" tables.
 ### Docs
 
 - **README + docs restructure** — slim README ≤60 lines, create
-  `docs/config.md` as the single source of truth for `.cc-voice.toml`,
+  `docs/config.md` as the single source of truth for `.cc-senses.toml`,
   add `docs/engines.md`, dedupe SKILL.md config sections. Partly tracked
   in **#60** (doc hierarchy restructure); `docs/architecture.md` and
   `CONTRIBUTING.md` already shipped in v0.6.0.
 - **ADR-0002 "full-duplex voice" future direction** — PersonaPlex / Moshi
-  architecture note. Historical record; cc-voice stays half-duplex with
+  architecture note. Historical record; cc-senses-bridge stays half-duplex with
   pluggable engines by design. Write when someone asks about the
   architectural frontier.
 - **6-line terseness prompt** in `.claude/rules/core-principles.md` — per
@@ -84,8 +84,8 @@ subsystem's "Rejected" section.
 |---|---|
 | **TurboQuant-GPU** (DevTechJr) | KV cache compression for text LLMs; NVIDIA-only; no VLM/audio support. Scope mismatch. |
 | **caveman as plugin** | Real savings are 13-21% per independent benchmark (not the viral 65-75% claim). Redundant with `core-principles.md` + `rtk` already in place. A 6-line prompt matches the full plugin's effect. |
-| **Claude Code router as cc-voice dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-voice's audio/vision pipeline is unaffected by backend routing. |
-| **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-voice doesn't need to re-document external tools. |
+| **Claude Code router as cc-senses-bridge dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-senses-bridge's audio/vision pipeline is unaffected by backend routing. |
+| **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-senses-bridge doesn't need to re-document external tools. |
 | **`context-mode`** deep research | Unresearched, not urgent. Revisit only if `rtk`'s command-output compression proves insufficient. |
 
 ## Process notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "cc-voice"
-version = "0.7.0"
-description = "End-to-end voice plugin for Claude Code — TTS output and STT input"
+name = "cc-senses-bridge"
+version = "0.8.0"
+description = "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see)"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [{ name = "qte77" }]
@@ -17,10 +17,10 @@ see = ["mss>=9.0.0", "Pillow>=10.0.0", "blake3>=0.4.0"]
 # ROCm), typically via abetlen's prebuilt wheel indexes. See
 # `make setup_see` output and skills/see/SKILL.md for install guidance.
 all = [
-    "cc-voice[piper]",
-    "cc-voice[edge]",
-    "cc-voice[stt]",
-    "cc-voice[see]",
+    "cc-senses-bridge[piper]",
+    "cc-senses-bridge[edge]",
+    "cc-senses-bridge[stt]",
+    "cc-senses-bridge[see]",
 ]
 dev = ["ruff>=0.15.10", "pyright>=1.1.408", "bump-my-version>=1.3.0"]
 test = ["pytest>=9.0.3", "pytest-cov>=6.0"]
@@ -94,7 +94,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.8.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/skills/listen/SKILL.md
+++ b/skills/listen/SKILL.md
@@ -24,7 +24,7 @@ python -m cc_stt $ARGUMENTS
 
 ## Configuration
 
-See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[stt]` section for the full schema and `CC_STT_*` env overrides.
+See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) `[stt]` section for the full schema and `CC_STT_*` env overrides.
 
 ## Status
 

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -19,7 +19,7 @@ make setup_see           # default: Moondream2 (~0.9 GB Q4, fastest CPU)
 make setup_see_qwen25    # alt: Qwen2.5-VL-3B (~1.6 GB Q4, richer output)
 ```
 
-Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-voice/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-voice.toml`. See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) for the full `[vlm]` schema.
+Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-bridge/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) for the full `[vlm]` schema.
 
 ## Usage
 
@@ -51,7 +51,7 @@ make smoke                           # imports + --help + full test suite
 
 ```bash
 make plugin_validate                 # sanity-check the manifest first
-make plugin_install_local            # registers local marketplace + installs cc-voice (project scope)
+make plugin_install_local            # registers local marketplace + installs cc-senses-bridge (project scope)
 make run_cc                          # starts claude; then type /see in the session
 make plugin_uninstall                # removes plugin + marketplace when done
 ```
@@ -64,7 +64,7 @@ python -m cc_vlm $ARGUMENTS
 
 ## Configuration
 
-See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[vlm]` section for the full schema and `CC_VLM_*` env overrides. Supported `handler_name` values are listed in [`docs/architecture.md`](../../docs/architecture.md#supported-vlm-models-llama-cpp-python-handlers).
+See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) `[vlm]` section for the full schema and `CC_VLM_*` env overrides. Supported `handler_name` values are listed in [`docs/architecture.md`](../../docs/architecture.md#supported-vlm-models-llama-cpp-python-handlers).
 
 ## Token budget and rationale
 
@@ -80,7 +80,7 @@ For an end-to-end user flow (feeding screen content to Claude so it can debug or
 |---|---|
 | Per-session cache (in-memory `DescribeCache`) | Exits with the Python process. Nothing to clean. |
 | Temp JPEGs (`/tmp/tmp*.jpg`) | `make clean_see_artifacts` |
-| Downloaded GGUF + mmproj (`~/.cache/cc-voice/models/`) | `make clean_models` |
+| Downloaded GGUF + mmproj (`~/.cache/cc-senses-bridge/models/`) | `make clean_models` |
 | Python venv + pytest/ruff caches | `make clean` |
 | All of the above at once | `make clean_all` |
 | Plugin installation (if done via `make plugin_install_local`) | `make plugin_uninstall` |

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -24,7 +24,7 @@ uv run python -m cc_tts.speak $ARGUMENTS
 
 ## Configuration
 
-See [`.cc-voice.example.toml`](../../.cc-voice.example.toml) `[tts]` section for the full schema and `CC_TTS_*` env overrides.
+See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) `[tts]` section for the full schema and `CC_TTS_*` env overrides.
 
 ## Delivery modes
 

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
-"""cc-stt: Speech-to-text module for cc-voice plugin."""
+"""cc-stt: Speech-to-text module for cc-senses-bridge plugin."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/cc_stt/config.py
+++ b/src/cc_stt/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading from .cc-voice.toml [stt] section and environment variables."""
+"""Configuration loading from .cc-senses.toml [stt] section and environment variables."""
 
 from __future__ import annotations
 
@@ -38,5 +38,5 @@ class STTConfig(BaseSettings):
 
 
 def load_stt_config() -> STTConfig:
-    """Load STT config from [stt] section of .cc-voice.toml with env var overrides."""
+    """Load STT config from [stt] section of .cc-senses.toml with env var overrides."""
     return STTConfig(**load_toml_section("stt"))

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
-"""CC-Voice: End-to-end voice plugin for Claude Code."""
+"""cc-senses-bridge: Local multimodal I/O bridge for Claude Code (TTS module)."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/cc_tts/config.py
+++ b/src/cc_tts/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading from .cc-voice.toml [tts] section and environment variables."""
+"""Configuration loading from .cc-senses.toml [tts] section and environment variables."""
 
 from __future__ import annotations
 
@@ -36,5 +36,5 @@ class TTSConfig(BaseSettings):
 
 
 def load_config() -> TTSConfig:
-    """Load config from .cc-voice.toml [tts] section with env var overrides."""
+    """Load config from .cc-senses.toml [tts] section with env var overrides."""
     return TTSConfig(**load_toml_section("tts"))

--- a/src/cc_tts/hook_handler.py
+++ b/src/cc_tts/hook_handler.py
@@ -1,7 +1,7 @@
 """Stop hook handler for auto-read mode.
 
 This hook fires on EVERY Claude response (registered as a Stop hook in
-hooks/hooks.json via the cc-voice plugin). It is intentionally always-registered rather than
+hooks/hooks.json via the cc-senses-bridge plugin). It is intentionally always-registered rather than
 dynamically added/removed because CC hooks don't hot-reload — they require
 a session restart to take effect.
 
@@ -31,9 +31,9 @@ from pathlib import Path
 
 from cc_tts.config import load_config
 
-# Debug log path: ~/.cache/cc-voice/hook.log
+# Debug log path: ~/.cache/cc-senses-bridge/hook.log
 # Set CC_TTS_HOOK_DEBUG=1 to enable; disabled by default.
-_LOG_PATH = Path.home() / ".cache" / "cc-voice" / "hook.log"
+_LOG_PATH = Path.home() / ".cache" / "cc-senses-bridge" / "hook.log"
 
 
 def extract_assistant_text(stdin_data: str) -> str:
@@ -65,7 +65,7 @@ def main() -> None:
     child synthesizes and plays in background.
 
     Graceful no-op when deps are missing (team members without TTS setup).
-    Set CC_TTS_HOOK_DEBUG=1 to log diagnostics to ~/.cache/cc-voice/hook.log.
+    Set CC_TTS_HOOK_DEBUG=1 to log diagnostics to ~/.cache/cc-senses-bridge/hook.log.
     """
     _debug("hook fired")
 

--- a/src/cc_tts/repl.py
+++ b/src/cc_tts/repl.py
@@ -178,7 +178,7 @@ def main() -> None:
         args=(proc.stdout, _make_on_text(response_text, first_delta, sentence_buf), turn_done),
         daemon=True,
     ).start()
-    print("cc-voice REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read\n")
+    print("cc-senses-bridge REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read\n")
 
     last_interrupt = 0.0
 

--- a/src/cc_tts/speak.py
+++ b/src/cc_tts/speak.py
@@ -17,7 +17,7 @@ from cc_tts.preprocess import preprocess
 _output_counter = 0
 
 # PID file for --stop interrupt. Stores the current speak PGID (process group).
-_PID_FILE = Path.home() / ".cache" / "cc-voice" / "speak.pid"
+_PID_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "speak.pid"
 
 
 def _write_pidfile() -> None:
@@ -94,12 +94,12 @@ def synthesize_and_play(text: str, config: TTSConfig | None = None) -> None:
 
 
 def _toggle_auto_read() -> None:
-    """Toggle auto_read in .cc-voice.toml [tts] section."""
+    """Toggle auto_read in .cc-senses.toml [tts] section."""
     from cc_voice_common.config import find_config_file
 
     config_path = find_config_file()
     if config_path is None:
-        print("No .cc-voice.toml found — create one first", file=sys.stderr)
+        print("No .cc-senses.toml found — create one first", file=sys.stderr)
         sys.exit(1)
 
     content = config_path.read_text()
@@ -110,17 +110,17 @@ def _toggle_auto_read() -> None:
         content = content.replace("auto_read = false", "auto_read = true", 1)
         print("auto_read: false → true")
     else:
-        print("auto_read field not found in .cc-voice.toml [tts] section", file=sys.stderr)
+        print("auto_read field not found in .cc-senses.toml [tts] section", file=sys.stderr)
         sys.exit(1)
     config_path.write_text(content)
 
 
 def main() -> None:
-    """CLI entry point for cc-voice speak.
+    """CLI entry point for cc-senses-bridge speak.
 
     Usage:
         python -m cc_tts.speak <text>       speak the given text
-        python -m cc_tts.speak --toggle     flip auto_read in .cc-voice.toml
+        python -m cc_tts.speak --toggle     flip auto_read in .cc-senses.toml
         python -m cc_tts.speak --help       show usage
     """
     if "--help" in sys.argv or "-h" in sys.argv:
@@ -128,7 +128,7 @@ def main() -> None:
         print("  <text>    Speak the given text via the configured TTS engine")
         print("  --stream  Stream audio directly to player (no temp files)")
         print("  --stop    Interrupt ongoing TTS playback (SIGTERM to process group)")
-        print("  --toggle  Flip auto_read in .cc-voice.toml (enables/disables Stop hook TTS)")
+        print("  --toggle  Flip auto_read in .cc-senses.toml (enables/disables Stop hook TTS)")
         print("  --help    Show this message")
         return
 

--- a/src/cc_tts/stream_json.py
+++ b/src/cc_tts/stream_json.py
@@ -76,7 +76,7 @@ def main() -> None:
     if len(sys.argv) < 2 or "--help" in sys.argv or "-h" in sys.argv:
         print("Usage: cc-tts-stream [--speed <float>] <prompt>")
         print("  Sends prompt to Claude, speaks the response via TTS.")
-        print("  --speed  Override TTS speed (default: from .cc-voice.toml)")
+        print("  --speed  Override TTS speed (default: from .cc-senses.toml)")
         sys.exit(0 if "--help" in sys.argv or "-h" in sys.argv else 1)
 
     if shutil.which("claude") is None:

--- a/src/cc_tts/tts_worker.py
+++ b/src/cc_tts/tts_worker.py
@@ -47,4 +47,4 @@ def _speak_batch(speak: Callable[[str], None], batch: list[str]) -> None:
     try:
         speak(text)
     except Exception as exc:
-        print(f"[cc-voice] TTS error: {exc}", file=sys.stderr)
+        print(f"[cc-senses-bridge] TTS error: {exc}", file=sys.stderr)

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading from .cc-voice.toml [vlm] section and environment variables."""
+"""Configuration loading from .cc-senses.toml [vlm] section and environment variables."""
 
 from __future__ import annotations
 
@@ -41,5 +41,5 @@ class VLMConfig(BaseSettings):
 
 
 def load_vlm_config() -> VLMConfig:
-    """Load VLM config from [vlm] section of .cc-voice.toml with env var overrides."""
+    """Load VLM config from [vlm] section of .cc-senses.toml with env var overrides."""
     return VLMConfig(**load_toml_section("vlm"))

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -214,7 +214,7 @@ def resolve_vlm_engine(
         "No VLM engine available. Run `make setup_see` for guided "
         "installation (downloads models, prints the matching "
         "llama-cpp-python install command for your hardware). Then set "
-        "[vlm] model_path + mmproj_path in .cc-voice.toml or export "
+        "[vlm] model_path + mmproj_path in .cc-senses.toml or export "
         "CC_VLM_MODEL_PATH and CC_VLM_MMPROJ_PATH."
     )
     raise RuntimeError(msg)
@@ -230,12 +230,12 @@ def _unavailable_message(engine: LlamaCppVLMEngine) -> str:
             "hardware — see `make setup_see` output or skills/see/SKILL.md."
         )
     if not engine.model_path:
-        return "No [vlm] model_path configured. Set in .cc-voice.toml or export CC_VLM_MODEL_PATH."
+        return "No [vlm] model_path configured. Set in .cc-senses.toml or export CC_VLM_MODEL_PATH."
     if not Path(engine.model_path).exists():
         return f"VLM model file not found: {engine.model_path}"
     if not engine.mmproj_path:
         return (
-            "No [vlm] mmproj_path configured. Set in .cc-voice.toml or export CC_VLM_MMPROJ_PATH."
+            "No [vlm] mmproj_path configured. Set in .cc-senses.toml or export CC_VLM_MMPROJ_PATH."
         )
     if not Path(engine.mmproj_path).exists():
         return f"VLM mmproj file not found: {engine.mmproj_path}"

--- a/src/cc_voice_common/__init__.py
+++ b/src/cc_voice_common/__init__.py
@@ -1,1 +1,1 @@
-"""Shared utilities for cc-voice plugins."""
+"""Shared utilities for cc-senses-bridge plugins."""

--- a/src/cc_voice_common/config.py
+++ b/src/cc_voice_common/config.py
@@ -1,4 +1,4 @@
-"""Shared config utilities — TOML discovery and section loading for cc-voice plugins."""
+"""Shared config utilities — TOML discovery and section loading for cc-senses-bridge plugins."""
 
 from __future__ import annotations
 
@@ -6,11 +6,11 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-CONFIG_FILENAMES = [".cc-voice.toml"]
+CONFIG_FILENAMES = [".cc-senses.toml"]
 
 
 def find_config_file() -> Path | None:
-    """Walk up from cwd to find .cc-voice.toml."""
+    """Walk up from cwd to find .cc-senses.toml."""
     current = Path.cwd()
     for directory in [current, *current.parents]:
         for filename in CONFIG_FILENAMES:
@@ -21,7 +21,7 @@ def find_config_file() -> Path | None:
 
 
 def load_toml_section(section: str) -> dict[str, Any]:
-    """Load a section from .cc-voice.toml, returning {} if not found."""
+    """Load a section from .cc-senses.toml, returning {} if not found."""
     config_file = find_config_file()
     if config_file is None:
         return {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ class TestLoadConfigFromToml:
 
         mp = pytest.MonkeyPatch()  # noqa: F841
         toml_content = b'[tts]\nengine = "espeak"\nvoice = "en_GB-alan"\nspeed = 1.5\n'
-        config_file = tmp_path / ".cc-voice.toml"
+        config_file = tmp_path / ".cc-senses.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_config()
@@ -41,7 +41,7 @@ class TestLoadConfigFromToml:
 class TestEnvOverrides:
     def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: object) -> None:
         toml_content = b'[tts]\nengine = "espeak"\n'
-        config_file = tmp_path / ".cc-voice.toml"
+        config_file = tmp_path / ".cc-senses.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         monkeypatch.setenv("CC_TTS_ENGINE", "piper")  # type: ignore[union-attr]

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -27,11 +27,11 @@ class TestSTTConfigDefaults:
 
 
 class TestLoadSTTConfigFromToml:
-    def test_loads_from_cc_voice_toml_stt_section(
+    def test_loads_from_cc_senses_toml_stt_section(
         self, tmp_path: Path, monkeypatch: object
     ) -> None:
         toml_content = b'[stt]\nengine = "moonshine"\nlanguage = "de"\n'
-        config_file = tmp_path / ".cc-voice.toml"
+        config_file = tmp_path / ".cc-senses.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_stt_config()
@@ -47,7 +47,7 @@ class TestLoadSTTConfigFromToml:
         self, tmp_path: Path, monkeypatch: object
     ) -> None:
         toml_content = b'[tts]\nengine = "piper"\n'
-        config_file = tmp_path / ".cc-voice.toml"
+        config_file = tmp_path / ".cc-senses.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         config = load_stt_config()
@@ -57,7 +57,7 @@ class TestLoadSTTConfigFromToml:
 class TestSTTEnvOverrides:
     def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: object) -> None:
         toml_content = b'[stt]\nengine = "moonshine"\n'
-        config_file = tmp_path / ".cc-voice.toml"
+        config_file = tmp_path / ".cc-senses.toml"
         config_file.write_bytes(toml_content)
         monkeypatch.chdir(tmp_path)  # type: ignore[union-attr]
         monkeypatch.setenv("CC_STT_ENGINE", "vosk")  # type: ignore[union-attr]

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -93,7 +93,7 @@ class TestLoadVLMConfig:
     def test_loads_from_vlm_toml_section(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        (tmp_path / ".cc-voice.toml").write_text(
+        (tmp_path / ".cc-senses.toml").write_text(
             "[vlm]\n"
             'engine = "llamacpp"\n'
             'model_path = "/models/qwen.gguf"\n'
@@ -110,7 +110,7 @@ class TestLoadVLMConfig:
         assert config.max_dimension == 512
 
     def test_env_overrides_toml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        (tmp_path / ".cc-voice.toml").write_text('[vlm]\nmodel_path = "/toml/path.gguf"\n')
+        (tmp_path / ".cc-senses.toml").write_text('[vlm]\nmodel_path = "/toml/path.gguf"\n')
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("CC_VLM_MODEL_PATH", "/env/path.gguf")
         config = load_vlm_config()
@@ -119,7 +119,7 @@ class TestLoadVLMConfig:
     def test_ignores_unknown_vlm_keys(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        (tmp_path / ".cc-voice.toml").write_text(
+        (tmp_path / ".cc-senses.toml").write_text(
             '[vlm]\nengine = "llamacpp"\nunknown_field = "should_be_dropped"\n'
         )
         monkeypatch.chdir(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -270,8 +270,8 @@ wheels = [
 ]
 
 [[package]]
-name = "cc-voice"
-version = "0.6.0"
+name = "cc-senses-bridge"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-settings" },
@@ -314,10 +314,10 @@ test = [
 requires-dist = [
     { name = "blake3", marker = "extra == 'see'", specifier = ">=0.4.0" },
     { name = "bump-my-version", marker = "extra == 'dev'", specifier = ">=1.3.0" },
-    { name = "cc-voice", extras = ["edge"], marker = "extra == 'all'" },
-    { name = "cc-voice", extras = ["piper"], marker = "extra == 'all'" },
-    { name = "cc-voice", extras = ["see"], marker = "extra == 'all'" },
-    { name = "cc-voice", extras = ["stt"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras =["edge"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras =["piper"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras =["see"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras =["stt"], marker = "extra == 'all'" },
     { name = "edge-tts", marker = "extra == 'edge'", specifier = ">=7.2.8" },
     { name = "mss", marker = "extra == 'see'", specifier = ">=9.0.0" },
     { name = "pillow", marker = "extra == 'see'", specifier = ">=10.0.0" },


### PR DESCRIPTION
## Summary

Renames the project from \`cc-voice\` → \`cc-senses-bridge\` to reflect the full multimodal scope (TTS + STT + VLM) rather than voice-only.

- **Repo / plugin slug**: \`cc-voice\` → \`cc-senses-bridge\` (in \`plugin.json\`, \`marketplace.json\`, \`pyproject.toml\`, install commands, badges, docs)
- **Config file**: \`.cc-voice.toml\` → \`.cc-senses.toml\` (and \`.example\` variant). Loader updated in \`src/cc_voice_common/config.py\`; tests updated.
- **Cache directory**: \`~/.cache/cc-voice/\` → \`~/.cache/cc-senses-bridge/\` (VLM models, \`speak.pid\`, \`hook.log\`)
- **Version**: \`0.7.0\` → \`0.8.0\` (matched across plugin.json, marketplace.json, pyproject.toml, \`cc_tts/__init__.py\`, \`cc_stt/__init__.py\`, README badge, bumpversion config)
- **Python modules kept**: \`cc_tts\`, \`cc_stt\`, \`cc_vlm\`, \`cc_voice_common\` — intentionally not renamed to avoid import-graph churn

## Migration for users

After merge, users on a previous install need to:

1. Move \`.cc-voice.toml\` → \`.cc-senses.toml\` (same schema; no field changes)
2. Move cached VLM models from \`~/.cache/cc-voice/models/\` → \`~/.cache/cc-senses-bridge/models/\`, or re-run \`make setup_see\`
3. \`make plugin_uninstall && make plugin_install_local\`

Documented in CHANGELOG [0.8.0] Migration notes.

## Follow-up (manual, after merge)

- \`gh repo rename qte77/cc-voice-plugin-prototype cc-senses-bridge\` — GitHub redirects the old URL but stale local clones need \`git remote set-url origin <new-url>\` on next push.

## Validation

\`make validate\` could not run locally — the sandbox blocks writes to \`~/.cache/uv/\`. CI should run the full lint + type + test suite.

## Test plan

- [ ] CI: lint, types, tests green
- [ ] \`make smoke_imports\` runs (imports work with renamed package metadata)
- [ ] \`make plugin_install_local\` installs as \`cc-senses-bridge@cc-senses-bridge\`
- [ ] \`.cc-senses.toml\` is discovered by the config loader

Generated with Claude <noreply@anthropic.com>