### PR TITLE
feat(vlm): LlamaServerVLMEngine HTTP backend (#101)

### DIFF
--- a/.cc-senses.example.toml
+++ b/.cc-senses.example.toml
@@ -29,9 +29,11 @@ max_words = 200              # Hard word cap on transcriptions
 # VLM settings (env overrides: CC_VLM_ENGINE, CC_VLM_MODEL_PATH,
 # CC_VLM_MMPROJ_PATH, CC_VLM_HANDLER_NAME, CC_VLM_N_CTX,
 # CC_VLM_N_GPU_LAYERS, CC_VLM_MAX_TOKENS, CC_VLM_MAX_DIMENSION,
-# CC_VLM_JPEG_QUALITY, CC_VLM_TEMPLATE, CC_VLM_CACHE_SIZE)
+# CC_VLM_JPEG_QUALITY, CC_VLM_TEMPLATE, CC_VLM_CACHE_SIZE,
+# CC_VLM_SERVER_URL, CC_VLM_SERVER_MODEL_ALIAS, CC_VLM_SERVER_PORT,
+# CC_VLM_SERVER_BINARY, CC_VLM_AUTO_SPAWN, CC_VLM_PRELOAD)
 [vlm]
-engine = "auto"              # "auto" | "llamacpp"
+engine = "auto"              # "auto" | "llamacpp" | "llamaserver"
 model_path = ""              # Absolute path to .gguf vision model (set by `make setup_see`)
 mmproj_path = ""             # Absolute path to mmproj (CLIP projector) .gguf
 handler_name = "moondream"   # Default: Moondream2 (~0.9 GB Q4, fastest CPU path)
@@ -44,3 +46,15 @@ max_dimension = 768          # Resize longest edge before VLM (tokens ∝ dimens
 jpeg_quality = 85
 template = "generic"         # Default template if --template not passed
 cache_size = 32              # Per-invocation LRU entries
+
+# llama-server HTTP backend (alternative to llama-cpp-python in-process).
+# Routes around the llama-cpp-python chat-handler gap (Qwen3-VL, SmolVLM2).
+# Phase 1 wires server_url + server_model_alias; lifecycle fields below
+# (server_port / server_binary / auto_spawn / preload) are inert until
+# Phase 2 / Phase 3 land.
+server_url = ""              # e.g. "http://localhost:8080" — empty disables the HTTP engine
+server_model_alias = ""      # OpenAI-style model name; usually unused — llama-server accepts any
+server_port = 8080           # Used by Phase 2 auto-spawn
+server_binary = "llama-server"  # PATH lookup or absolute path
+auto_spawn = true            # (Phase 2) lazy spawn on first /see if no reachable server
+preload = false              # (Phase 3) SessionStart hook spawns server eagerly

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,14 +77,14 @@ See `docs/adr/0002-stt-engine-selection.md` for rationale.
 **Flow**: screen capture → resize (longest edge ≤ 768 px) → BLAKE3 hash →
 cache check → VLM → text description → inject into prompt
 
-Engine priority (auto-detect order): `llamacpp` (only MVP engine)
+Engine priority (auto-detect order): `llamacpp` → `llamaserver` (in-process preferred when configured; HTTP fallback when only `server_url` is set)
 
 ### VLM engine comparison
 
 | Engine | Backend | Daemon | RAM idle | Latency (warm) | Notes |
 |---|---|---|---|---|---|
-| **llamacpp** (default) | llama-cpp-python | None | 0 | ~200-500 ms | In-process; no HTTP |
-| LlamaServerVLMEngine (planned) | `llama-server` HTTP | Yes (user-managed) | ~1-2 GB | ~200-500 ms | Same llama.cpp binary as in-process; unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs |
+| **llamacpp** (default) | llama-cpp-python | None | 0 (but cold-starts every `/see` — fresh Python process) | ~200-500 ms (within one process; rare for CLI) | In-process; no HTTP. Cold-starts on every `/see` invocation. |
+| **llamaserver** | `llama-server` HTTP | Yes (user-managed in Phase 1; lazy auto-spawn in Phase 2; preloaded in Phase 3) | ~1-2 GB while alive | ~200-500 ms (genuinely warm across `/see` calls) | Same llama.cpp binary as in-process; unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs |
 | ClaudeVisionEngine (deferred) | Claude Vision API | None | 0 | ~1-3 s | ~1,600 tokens/call; opt-in `--vision` |
 
 **Why `llama-server` and not Ollama**: same llama.cpp binary already used by the in-process path, no extra daemon family to support, no Ollama-as-dependency. Ollama was considered and rejected on those grounds during the #91 research pass.

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -105,8 +105,12 @@ and the supported-handlers table for full details.
 | `minicpmv` | MiniCPM-V 2.6 | Apache 2.0 |
 | `nanollava` | NanoLLaVA | Apache 2.0 |
 
-All shipped via the single `LlamaCppVLMEngine` class in
-`src/cc_vlm/engine.py`, dispatched on `handler_name`.
+Shipped via two engine classes in `src/cc_vlm/engine.py`:
+
+- `LlamaCppVLMEngine` — in-process via llama-cpp-python (dispatched on `handler_name`).
+- `LlamaServerVLMEngine` — HTTP via llama-server (PR #107/#108; user-managed in Phase 1, lazy auto-spawn in Phase 2, SessionStart preload in Phase 3). Routes around the abetlen/llama-cpp-python handler gap and gives genuinely-warm-across-invocations latency, which the in-process backend cannot in the `/see` CLI workflow (each `/see` spawns a fresh Python process).
+
+**SmolVLM2-2.2B** and **Qwen3-VL-2B** are reachable today via the `llamaserver` engine — both are blocked on missing `*ChatHandler` classes in `abetlen/llama-cpp-python` (Qwen3-VL: upstream #2080; SmolVLM2: no handler upstream at all).
 
 ### Considered / deferred
 
@@ -114,11 +118,9 @@ To be filed as issues; placeholder list for now.
 
 | Candidate | Status | Notes |
 |---|---|---|
-| **`LlamaServerVLMEngine` HTTP backend** | deferred (Phase 2) | Same `llama.cpp` binary as the in-process path — adds an HTTP-server engine class so users can run any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs. Unlocks SmolVLM2-2.2B and Qwen3-VL-2B on the day llama.cpp supports them. Ollama considered and rejected (extra daemon family, Ollama-as-dependency). |
-| **`Qwen3VLChatHandler` for in-process backend** | deferred (Phase 3) | Blocked on [`abetlen/llama-cpp-python` #2080](https://github.com/abetlen/llama-cpp-python/issues/2080). Add `"qwen3vl"` to `_HANDLER_MAP` once the upstream class lands. Until then, `LlamaServerVLMEngine` (above) is the unblock path. |
-| **`available()` hardening for handler-class-mismatch** | deferred | `engine.py:available()` only checks `handler_name in _HANDLER_MAP`, not whether the class actually exists in the installed `llama_cpp.llama_chat_format` module. Latent footgun for any new handler we add. |
+| **`Qwen3VLChatHandler` for in-process backend** | deferred (tracker #102) | Blocked on [`abetlen/llama-cpp-python` #2080](https://github.com/abetlen/llama-cpp-python/issues/2080). Add `"qwen3vl"` to `_HANDLER_MAP` once the upstream class lands. Until then, `LlamaServerVLMEngine` is the unblock path. |
+| **`available()` hardening for handler-class-mismatch** | deferred (tracker #103) | `engine.py:available()` only checks `handler_name in _HANDLER_MAP`, not whether the class actually exists in the installed `llama_cpp.llama_chat_format` module. Latent footgun for any new handler we add. |
 | **`ClaudeVisionEngine` fallback** | deferred (per ADR-0003 Tier 1) | Returns image path reference for Claude's built-in vision instead of running a local VLM. ~1,600 tokens/call (vs ~120 for local VLM). Opt-in `--vision` flag. |
-| **SmolVLM2-2.2B** | deferred via `LlamaServerVLMEngine` | Apache 2.0, ~1.1 GB Q4, designed for on-device CPU. No `SmolVLMChatHandler` in `abetlen/llama-cpp-python`; reachable today only via `llama-server`. |
 
 ### Rejected
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["pydantic-settings>=2.9.1"]
 piper = ["piper-tts>=1.2.0"]
 edge = ["edge-tts>=7.2.8"]
 stt = ["sounddevice>=0.5.0"]
-see = ["mss>=9.0.0", "Pillow>=10.0.0", "blake3>=0.4.0"]
+see = ["mss>=9.0.0", "Pillow>=10.0.0", "blake3>=0.4.0", "httpx>=0.27"]
 # NOTE: llama-cpp-python is intentionally NOT in [see] extras.
 # Users install the variant matching their hardware (CPU / CUDA / Metal /
 # ROCm), typically via abetlen's prebuilt wheel indexes. See

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -21,6 +21,39 @@ make setup_see_qwen25    # alt: Qwen2.5-VL-3B (~1.6 GB Q4, richer output)
 
 Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-bridge/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) for the full `[vlm]` schema.
 
+## Engines
+
+Two engines are available; auto-detect picks the first one that's configured.
+
+| Engine | When to use | Tradeoff |
+|---|---|---|
+| `llamacpp` (in-process) | You have `model_path` + `mmproj_path` set and the appropriate `llama-cpp-python` chat handler exists for your model family | No daemon; reloads the model on every `/see` call (each invocation is a fresh Python process) |
+| `llamaserver` (HTTP) | You want a hot model across `/see` calls, or you're using SmolVLM2 / Qwen3-VL where the in-process handler doesn't exist yet | User runs `llama-server` separately; ~1-2 GB RAM while alive; warm response within 200-500 ms |
+
+### Using a llama-server backend (manual)
+
+For SmolVLM2-2.2B, Qwen3-VL-2B, or any GGUF llama.cpp supports but `llama-cpp-python` doesn't yet:
+
+1. Install `llama.cpp` and ensure `llama-server` is on your PATH.
+2. Start the server with your model + mmproj:
+
+   ```bash
+   llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
+   ```
+
+3. Configure cc-senses-bridge to talk to it. Add to `.cc-senses.toml`:
+
+   ```toml
+   [vlm]
+   engine = "llamaserver"
+   server_url = "http://localhost:8080"
+   # server_model_alias is usually unused — llama-server accepts any name
+   ```
+
+4. Run `/see` as usual. The model stays resident in `llama-server` between invocations, so latency stays around the inference cost (~200-500 ms) instead of paying the 3-5 s model load on every call.
+
+> **Note**: Phase 1 ships manual server management only. Lazy auto-spawn (`auto_spawn = true`) and SessionStart preload (`preload = true`) land in subsequent PRs.
+
 ## Usage
 
 - `/see` — capture full screen, describe using the configured template (default: `generic`)

--- a/src/cc_tts/edge_stream.py
+++ b/src/cc_tts/edge_stream.py
@@ -113,11 +113,17 @@ def _stream_kokoro(text: str, *, voice: str, speed: float) -> None:
     try:
         subprocess.run(
             [
-                "kokoro-tts", txt_path, "--stream",
-                "--voice", voice or "af_sarah",
-                "--speed", str(speed),
-                "--model", str(model_dir / "kokoro-v1.0.onnx"),
-                "--voices", str(model_dir / "voices-v1.0.bin"),
+                "kokoro-tts",
+                txt_path,
+                "--stream",
+                "--voice",
+                voice or "af_sarah",
+                "--speed",
+                str(speed),
+                "--model",
+                str(model_dir / "kokoro-v1.0.onnx"),
+                "--voices",
+                str(model_dir / "voices-v1.0.bin"),
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/src/cc_tts/stream_filter.py
+++ b/src/cc_tts/stream_filter.py
@@ -56,7 +56,6 @@ class StreamFilter:
         clean = re.sub(r"[^\n]*\r", "", clean)
 
         for line in clean.split("\n"):
-
             # Code block toggle
             stripped = line.strip()
             if stripped.startswith("```"):

--- a/src/cc_tts/stream_json.py
+++ b/src/cc_tts/stream_json.py
@@ -137,7 +137,10 @@ def main() -> None:
         config = load_config()
         speed = speed_override if speed_override is not None else config.speed
         speak_streaming(
-            response, voice=config.voice, speed=speed, engine=config.engine,
+            response,
+            voice=config.voice,
+            speed=speed,
+            engine=config.engine,
         )
 
 

--- a/src/cc_vlm/__main__.py
+++ b/src/cc_vlm/__main__.py
@@ -125,6 +125,8 @@ def main(argv: list[str] | None = None) -> int:
             n_ctx=config.n_ctx,
             n_gpu_layers=config.n_gpu_layers,
             max_tokens=config.max_tokens,
+            server_url=config.server_url,
+            server_model_alias=config.server_model_alias,
         )
     except (RuntimeError, ValueError) as exc:
         print(f"cc_vlm: {exc}", file=sys.stderr)

--- a/src/cc_vlm/config.py
+++ b/src/cc_vlm/config.py
@@ -10,7 +10,18 @@ from cc_voice_common.config import load_toml_section
 
 
 class VLMConfig(BaseSettings):
-    """VLM plugin configuration for the llama-cpp-python in-process engine."""
+    """VLM plugin configuration.
+
+    Covers both engines:
+    - `LlamaCppVLMEngine` (in-process): `model_path` + `mmproj_path` +
+      `handler_name` + `n_ctx`/`n_gpu_layers`/`max_tokens`.
+    - `LlamaServerVLMEngine` (HTTP): `server_url` + `server_model_alias`
+      + (Phase 2) `server_port`/`server_binary`/`auto_spawn` +
+      (Phase 3) `preload`.
+
+    `max_dimension`/`jpeg_quality`/`template`/`cache_size` apply to the
+    capture+inference pipeline regardless of which engine is selected.
+    """
 
     model_config = SettingsConfigDict(env_prefix="CC_VLM_", extra="ignore")
 
@@ -25,6 +36,14 @@ class VLMConfig(BaseSettings):
     jpeg_quality: int = 85
     template: str = "generic"
     cache_size: int = 32
+    # llama-server HTTP backend (Phase 1 wires server_url + alias;
+    # remaining fields are inert until Phase 2 lifecycle work lands).
+    server_url: str = ""
+    server_model_alias: str = ""
+    server_port: int = 8080
+    server_binary: str = "llama-server"
+    auto_spawn: bool = True
+    preload: bool = False
 
     @classmethod
     def settings_customise_sources(

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -74,7 +74,11 @@ class LlamaCppVLMEngine:
         n_ctx: int = 4096,
         n_gpu_layers: int = 0,
         max_tokens: int = 256,
+        **_kwargs: Any,
     ) -> None:
+        # Reason: `_kwargs` absorbs server_url/server_model_alias etc. that
+        # `resolve_vlm_engine` forwards uniformly to every engine in
+        # `_ENGINE_TYPES`. They're meaningless for the in-process backend.
         self.model_path = model_path
         self.mmproj_path = mmproj_path
         self.handler_name = handler_name
@@ -163,7 +167,112 @@ class LlamaCppVLMEngine:
         return content.strip()
 
 
-_ENGINE_TYPES: list[type[LlamaCppVLMEngine]] = [LlamaCppVLMEngine]
+class LlamaServerVLMEngine:
+    """HTTP VLM engine that talks to `llama-server` over its OpenAI-compatible API.
+
+    Routes around the `abetlen/llama-cpp-python` chat-handler gap (issue
+    #102 for Qwen3-VL, no SmolVLMChatHandler upstream) by reaching the
+    same `llama.cpp` binary via its HTTP server. The user starts the
+    server themselves (Phase 1); we POST chat completions to it.
+
+    The server keeps the model resident in RAM across `/see` invocations,
+    so this path is *actually* warm — unlike the in-process engine,
+    which reloads on every fresh Python process.
+    """
+
+    def __init__(
+        self,
+        server_url: str = "",
+        server_model_alias: str = "",
+        max_tokens: int = 256,
+        **_kwargs: Any,
+    ) -> None:
+        # Reason: `_kwargs` absorbs model_path/handler_name/etc. forwarded
+        # uniformly by `resolve_vlm_engine`. Those are meaningless for the
+        # HTTP backend.
+        self.server_url = server_url.rstrip("/")
+        self.server_model_alias = server_model_alias
+        self.max_tokens = max_tokens
+
+    @property
+    def name(self) -> str:
+        return "llamaserver"
+
+    def available(self) -> bool:
+        """Check whether llama-server is reachable on `server_url`.
+
+        Returns False on: empty `server_url`, missing `httpx`, non-200
+        health response, connect error, or timeout. Does NOT spawn a
+        server here — that's Phase 2.
+        """
+        if not self.server_url:
+            return False
+        try:
+            import httpx
+        except ImportError:
+            return False
+        try:
+            response = httpx.get(f"{self.server_url}/health", timeout=2.0)
+        except Exception:  # noqa: BLE001
+            # Reason: httpx raises various subclasses (ConnectError,
+            # TimeoutException, ReadTimeout, etc.). All of them mean
+            # "server not reachable" — catch broadly so available()
+            # never propagates a transport error to the caller.
+            return False
+        return response.status_code == 200
+
+    def describe(self, image_path: Path, prompt: str) -> str:
+        """Read the image, POST a chat-completion to llama-server, return text.
+
+        Image is base64-encoded into a data URL — llama-server's vision
+        endpoints don't accept `file://` for security, and base64 is
+        portable across all llama.cpp builds.
+        """
+        import base64
+
+        import httpx
+
+        image_bytes = image_path.read_bytes()
+        image_b64 = base64.b64encode(image_bytes).decode("ascii")
+        mime = "image/png" if image_path.suffix.lower() == ".png" else "image/jpeg"
+        data_url = f"data:{mime};base64,{image_b64}"
+
+        body: dict[str, Any] = {
+            "model": self.server_model_alias,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                },
+            ],
+            "max_tokens": self.max_tokens,
+        }
+        response = httpx.post(
+            f"{self.server_url}/v1/chat/completions",
+            json=body,
+            timeout=60.0,
+        )
+        if response.status_code != 200:
+            msg = f"llama-server returned {response.status_code}: {response.text}"
+            raise RuntimeError(msg)
+        data = response.json()
+        choices = data.get("choices", [])
+        if not choices:
+            msg = f"llama-server returned no choices: {data}"
+            raise RuntimeError(msg)
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if not isinstance(content, str):
+            msg = f"llama-server returned unexpected content shape: {message}"
+            raise RuntimeError(msg)
+        return content.strip()
+
+
+_VLMEngineType = type[LlamaCppVLMEngine] | type[LlamaServerVLMEngine]
+_ENGINE_TYPES: list[_VLMEngineType] = [LlamaCppVLMEngine, LlamaServerVLMEngine]
 
 
 def resolve_vlm_engine(
@@ -171,18 +280,22 @@ def resolve_vlm_engine(
     *,
     model_path: str = "",
     mmproj_path: str = "",
-    handler_name: str = "qwen2.5vl",
+    handler_name: str = "moondream",
     n_ctx: int = 4096,
     n_gpu_layers: int = 0,
     max_tokens: int = 256,
+    server_url: str = "",
+    server_model_alias: str = "",
 ) -> VLMEngine:
     """Resolve a VLM engine by name or auto-detect first available.
 
-    Auto-detect order: LlamaCppVLMEngine (only MVP engine). Future:
-    LlamaServerVLMEngine alternative, ClaudeVisionEngine fallback.
+    Auto-detect order: LlamaCppVLMEngine (in-process) first, then
+    LlamaServerVLMEngine (HTTP). The in-process backend wins when both
+    are configured because it doesn't depend on an external daemon.
     """
-    name_map: dict[str, type[LlamaCppVLMEngine]] = {
+    name_map: dict[str, _VLMEngineType] = {
         "llamacpp": LlamaCppVLMEngine,
+        "llamaserver": LlamaServerVLMEngine,
     }
 
     kwargs: dict[str, Any] = {
@@ -192,6 +305,8 @@ def resolve_vlm_engine(
         "n_ctx": n_ctx,
         "n_gpu_layers": n_gpu_layers,
         "max_tokens": max_tokens,
+        "server_url": server_url,
+        "server_model_alias": server_model_alias,
     }
 
     if engine_name != "auto":
@@ -215,13 +330,40 @@ def resolve_vlm_engine(
         "installation (downloads models, prints the matching "
         "llama-cpp-python install command for your hardware). Then set "
         "[vlm] model_path + mmproj_path in .cc-senses.toml or export "
-        "CC_VLM_MODEL_PATH and CC_VLM_MMPROJ_PATH."
+        "CC_VLM_MODEL_PATH and CC_VLM_MMPROJ_PATH. Alternatively, run "
+        "`llama-server` and set [vlm] server_url for the HTTP backend."
     )
     raise RuntimeError(msg)
 
 
-def _unavailable_message(engine: LlamaCppVLMEngine) -> str:
+def _unavailable_message(engine: LlamaCppVLMEngine | LlamaServerVLMEngine) -> str:
     """Diagnose why a specific engine is unavailable."""
+    if isinstance(engine, LlamaServerVLMEngine):
+        return _llamaserver_unavailable_message(engine)
+    return _llamacpp_unavailable_message(engine)
+
+
+def _llamaserver_unavailable_message(engine: LlamaServerVLMEngine) -> str:
+    try:
+        import httpx  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError:
+        return (
+            "httpx not installed. Install the [see] extras: "
+            "`uv sync --extra see` — required for the llama-server backend."
+        )
+    if not engine.server_url:
+        return (
+            "No [vlm] server_url configured. Set in .cc-senses.toml or export "
+            "CC_VLM_SERVER_URL (e.g. http://localhost:8080)."
+        )
+    return (
+        f"llama-server unreachable at {engine.server_url}. "
+        "Start it with `llama-server -m model.gguf --mmproj mmproj.gguf --port 8080`, "
+        "or set [vlm] auto_spawn = true (Phase 2)."
+    )
+
+
+def _llamacpp_unavailable_message(engine: LlamaCppVLMEngine) -> str:
     try:
         import llama_cpp  # type: ignore[import-not-found]  # noqa: F401
     except ImportError:

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -34,9 +34,7 @@ def _make_dry_run(target: str) -> subprocess.CompletedProcess[str]:
 class TestSetupSee:
     def test_setup_see_target_exists(self, make_available: None) -> None:
         result = _make_dry_run("setup_see")
-        assert result.returncode == 0, (
-            f"setup_see target missing — stderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"setup_see target missing — stderr: {result.stderr}"
 
     def test_setup_see_runs_uv_sync_with_see_extra(self, make_available: None) -> None:
         result = _make_dry_run("setup_see")
@@ -48,9 +46,7 @@ class TestSetupSee:
         out = result.stdout.lower()
         assert "moondream" in out
 
-    def test_setup_see_does_not_reference_qwen25_as_default(
-        self, make_available: None
-    ) -> None:
+    def test_setup_see_does_not_reference_qwen25_as_default(self, make_available: None) -> None:
         """The Qwen2.5-VL alt is in setup_see_qwen25, not the default target."""
         result = _make_dry_run("setup_see")
         # The dry-run output for setup_see should not pull in Qwen2.5-VL URLs.
@@ -60,12 +56,8 @@ class TestSetupSee:
 class TestSetupSeeQwen25:
     def test_setup_see_qwen25_target_exists(self, make_available: None) -> None:
         result = _make_dry_run("setup_see_qwen25")
-        assert result.returncode == 0, (
-            f"setup_see_qwen25 target missing — stderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"setup_see_qwen25 target missing — stderr: {result.stderr}"
 
-    def test_setup_see_qwen25_references_qwen25_model(
-        self, make_available: None
-    ) -> None:
+    def test_setup_see_qwen25_references_qwen25_model(self, make_available: None) -> None:
         result = _make_dry_run("setup_see_qwen25")
         assert "Qwen2.5-VL" in result.stdout

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -24,6 +24,18 @@ class TestVLMConfigDefaults:
         assert config.template == "generic"
         assert config.cache_size == 32
 
+    def test_llama_server_field_defaults(self) -> None:
+        """Phase 1 introduces six llama-server fields; Phase 1 wires server_url
+        and server_model_alias; the remaining four land as inert fields ready
+        for Phase 2/3 lifecycle work."""
+        config = VLMConfig()
+        assert config.server_url == ""
+        assert config.server_model_alias == ""
+        assert config.server_port == 8080
+        assert config.server_binary == "llama-server"
+        assert config.auto_spawn is True
+        assert config.preload is False
+
 
 class TestEnvOverrides:
     @pytest.fixture(autouse=True)
@@ -79,6 +91,22 @@ class TestEnvOverrides:
     def test_env_missing_leaves_defaults(self) -> None:
         config = VLMConfig()
         assert config.engine == "auto"
+
+    def test_server_url_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CC_VLM_SERVER_URL", "http://localhost:8080")
+        monkeypatch.setenv("CC_VLM_SERVER_MODEL_ALIAS", "smolvlm2")
+        config = VLMConfig()
+        assert config.server_url == "http://localhost:8080"
+        assert config.server_model_alias == "smolvlm2"
+
+    def test_server_port_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CC_VLM_SERVER_PORT", "9090")
+        monkeypatch.setenv("CC_VLM_AUTO_SPAWN", "false")
+        monkeypatch.setenv("CC_VLM_PRELOAD", "true")
+        config = VLMConfig()
+        assert config.server_port == 9090
+        assert config.auto_spawn is False
+        assert config.preload is True
 
 
 class TestLoadVLMConfig:

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -436,19 +436,17 @@ def mock_httpx() -> MagicMock:
     class FakeConnectError(Exception):
         pass
 
-    class FakeTimeoutException(Exception):
+    class FakeTimeoutError(Exception):
         pass
 
     fake.ConnectError = FakeConnectError
-    fake.TimeoutException = FakeTimeoutException
+    fake.TimeoutException = FakeTimeoutError
 
     default_response = MagicMock()
     default_response.status_code = 200
     default_response.text = "OK"
     default_response.json.return_value = {
-        "choices": [
-            {"message": {"role": "assistant", "content": "A terminal showing git status."}}
-        ]
+        "choices": [{"message": {"role": "assistant", "content": "A terminal showing git status."}}]
     }
     fake.get.return_value = default_response
     fake.post.return_value = default_response

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -14,7 +14,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cc_vlm.engine import LlamaCppVLMEngine, VLMEngine, resolve_vlm_engine
+from cc_vlm.engine import (
+    LlamaCppVLMEngine,
+    LlamaServerVLMEngine,
+    VLMEngine,
+    resolve_vlm_engine,
+)
 
 
 @pytest.fixture
@@ -415,3 +420,261 @@ class TestResolveVLMEngine:
         finally:
             if saved is not None:
                 sys.modules["llama_cpp"] = saved
+
+
+@pytest.fixture
+def mock_httpx() -> MagicMock:
+    """Install a fake httpx module into sys.modules.
+
+    Returns the fake httpx MagicMock. Tests configure `.get.return_value`
+    and `.post.return_value` (or `.side_effect`) to drive engine behavior.
+    `fake_httpx.ConnectError` and `.TimeoutException` are wired to real
+    exception classes so engines can catch them by type.
+    """
+    fake = MagicMock()
+
+    class FakeConnectError(Exception):
+        pass
+
+    class FakeTimeoutException(Exception):
+        pass
+
+    fake.ConnectError = FakeConnectError
+    fake.TimeoutException = FakeTimeoutException
+
+    default_response = MagicMock()
+    default_response.status_code = 200
+    default_response.text = "OK"
+    default_response.json.return_value = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "A terminal showing git status."}}
+        ]
+    }
+    fake.get.return_value = default_response
+    fake.post.return_value = default_response
+
+    saved = sys.modules.get("httpx")
+    sys.modules["httpx"] = fake
+    yield fake
+    if saved is None:
+        sys.modules.pop("httpx", None)
+    else:
+        sys.modules["httpx"] = saved
+
+
+class TestLlamaServerVLMEngineDefaults:
+    def test_name(self) -> None:
+        assert LlamaServerVLMEngine().name == "llamaserver"
+
+    def test_defaults(self) -> None:
+        engine = LlamaServerVLMEngine()
+        assert engine.server_url == ""
+        assert engine.server_model_alias == ""
+        assert engine.max_tokens == 256
+
+    def test_strips_trailing_slash_from_url(self) -> None:
+        engine = LlamaServerVLMEngine(server_url="http://localhost:8080/")
+        assert engine.server_url == "http://localhost:8080"
+
+    def test_accepts_and_ignores_irrelevant_kwargs(self) -> None:
+        """Forwarded kwargs from resolve_vlm_engine for the in-process engine
+        must not break the HTTP engine's constructor."""
+        engine = LlamaServerVLMEngine(
+            server_url="http://localhost:8080",
+            model_path="/ignored.gguf",
+            mmproj_path="/ignored-mm.gguf",
+            handler_name="moondream",
+            n_ctx=4096,
+            n_gpu_layers=0,
+        )
+        assert engine.server_url == "http://localhost:8080"
+
+
+class TestLlamaServerVLMEngineAvailable:
+    def test_unavailable_when_server_url_empty(self) -> None:
+        engine = LlamaServerVLMEngine(server_url="")
+        assert engine.available() is False
+
+    def test_unavailable_when_httpx_missing(self) -> None:
+        """Without httpx installed, available() returns False (no crash)."""
+        saved = sys.modules.pop("httpx", None)
+        sys.modules["httpx"] = None  # type: ignore[assignment]
+        try:
+            engine = LlamaServerVLMEngine(server_url="http://localhost:8080")
+            assert engine.available() is False
+        finally:
+            sys.modules.pop("httpx", None)
+            if saved is not None:
+                sys.modules["httpx"] = saved
+
+    def test_available_when_health_200(self, mock_httpx: MagicMock) -> None:
+        engine = LlamaServerVLMEngine(server_url="http://localhost:8080")
+        assert engine.available() is True
+        mock_httpx.get.assert_called_once()
+        called_url = mock_httpx.get.call_args.args[0]
+        assert called_url == "http://localhost:8080/health"
+
+    def test_unavailable_when_health_503(self, mock_httpx: MagicMock) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        engine = LlamaServerVLMEngine(server_url="http://localhost:8080")
+        assert engine.available() is False
+
+    def test_unavailable_on_connect_error(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.get.side_effect = mock_httpx.ConnectError("refused")
+        engine = LlamaServerVLMEngine(server_url="http://localhost:8080")
+        assert engine.available() is False
+
+    def test_unavailable_on_timeout(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.get.side_effect = mock_httpx.TimeoutException("timeout")
+        engine = LlamaServerVLMEngine(server_url="http://localhost:8080")
+        assert engine.available() is False
+
+
+class TestLlamaServerVLMEngineDescribe:
+    @pytest.fixture
+    def engine(self) -> LlamaServerVLMEngine:
+        return LlamaServerVLMEngine(
+            server_url="http://localhost:8080",
+            server_model_alias="smolvlm2",
+            max_tokens=128,
+        )
+
+    def test_describe_returns_stripped_content(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_httpx.post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "  trimmed.  \n"}}]
+        }
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"\xff\xd8fake")
+
+        result = engine.describe(img, "what is this")
+
+        assert result == "trimmed."
+
+    def test_describe_posts_to_chat_completions(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"\xff\xd8fake")
+        engine.describe(img, "prompt")
+
+        called_url = mock_httpx.post.call_args.args[0]
+        assert called_url == "http://localhost:8080/v1/chat/completions"
+
+    def test_describe_body_has_model_and_base64_image(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"\xff\xd8fake")
+        engine.describe(img, "what is this")
+
+        body = mock_httpx.post.call_args.kwargs["json"]
+        assert body["model"] == "smolvlm2"
+        assert body["max_tokens"] == 128
+        content = body["messages"][0]["content"]
+        text_items = [c for c in content if c.get("type") == "text"]
+        image_items = [c for c in content if c.get("type") == "image_url"]
+        assert text_items[0]["text"] == "what is this"
+        url = image_items[0]["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+        # The encoded payload should round-trip to the original bytes
+        import base64
+
+        b64 = url.split(",", 1)[1]
+        assert base64.b64decode(b64) == b"\xff\xd8fake"
+
+    def test_describe_detects_png_mime(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        img = tmp_path / "x.png"
+        img.write_bytes(b"\x89PNGfake")
+        engine.describe(img, "p")
+
+        body = mock_httpx.post.call_args.kwargs["json"]
+        url = body["messages"][0]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+
+    def test_describe_raises_on_503(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        bad.text = "server overloaded"
+        mock_httpx.post.return_value = bad
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"x")
+
+        with pytest.raises(RuntimeError, match="503"):
+            engine.describe(img, "p")
+
+    def test_describe_raises_on_no_choices(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_httpx.post.return_value.json.return_value = {"choices": []}
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"x")
+
+        with pytest.raises(RuntimeError, match="no choices"):
+            engine.describe(img, "p")
+
+    def test_describe_raises_on_malformed_content(
+        self, engine: LlamaServerVLMEngine, mock_httpx: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_httpx.post.return_value.json.return_value = {
+            "choices": [{"message": {"content": ["unexpected", "list"]}}]
+        }
+        img = tmp_path / "x.jpg"
+        img.write_bytes(b"x")
+
+        with pytest.raises(RuntimeError, match="unexpected content shape"):
+            engine.describe(img, "p")
+
+
+class TestResolveVLMEngineWithLlamaServer:
+    def test_explicit_llamaserver_resolves(self, mock_httpx: MagicMock) -> None:
+        engine = resolve_vlm_engine("llamaserver", server_url="http://localhost:8080")
+        assert isinstance(engine, LlamaServerVLMEngine)
+
+    def test_explicit_llamaserver_unavailable_raises(self, mock_httpx: MagicMock) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        with pytest.raises(RuntimeError, match="unreachable"):
+            resolve_vlm_engine("llamaserver", server_url="http://localhost:8080")
+
+    def test_auto_falls_back_to_llamaserver_when_only_server_set(
+        self, mock_httpx: MagicMock
+    ) -> None:
+        """If model_path is empty but server_url is set and reachable, HTTP engine wins."""
+        engine = resolve_vlm_engine("auto", server_url="http://localhost:8080")
+        assert isinstance(engine, LlamaServerVLMEngine)
+
+    def test_auto_prefers_llamacpp_when_both_configured(
+        self,
+        mock_llama_cpp: tuple[MagicMock, MagicMock, MagicMock],
+        mock_httpx: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """In-process wins over HTTP when both are available (priority order)."""
+        model = tmp_path / "m.gguf"
+        mmproj = tmp_path / "mm.gguf"
+        model.write_bytes(b"x")
+        mmproj.write_bytes(b"x")
+        engine = resolve_vlm_engine(
+            "auto",
+            model_path=str(model),
+            mmproj_path=str(mmproj),
+            server_url="http://localhost:8080",
+        )
+        assert isinstance(engine, LlamaCppVLMEngine)
+
+    def test_unavailable_message_mentions_url(self, mock_httpx: MagicMock) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        with pytest.raises(RuntimeError) as exc_info:
+            resolve_vlm_engine("llamaserver", server_url="http://localhost:9999")
+        assert "http://localhost:9999" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -281,6 +281,7 @@ dependencies = [
 all = [
     { name = "blake3" },
     { name = "edge-tts" },
+    { name = "httpx" },
     { name = "mss" },
     { name = "pillow" },
     { name = "piper-tts" },
@@ -299,6 +300,7 @@ piper = [
 ]
 see = [
     { name = "blake3" },
+    { name = "httpx" },
     { name = "mss" },
     { name = "pillow" },
 ]
@@ -314,11 +316,12 @@ test = [
 requires-dist = [
     { name = "blake3", marker = "extra == 'see'", specifier = ">=0.4.0" },
     { name = "bump-my-version", marker = "extra == 'dev'", specifier = ">=1.3.0" },
-    { name = "cc-senses-bridge", extras =["edge"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras =["piper"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras =["see"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras =["stt"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras = ["edge"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras = ["piper"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras = ["see"], marker = "extra == 'all'" },
+    { name = "cc-senses-bridge", extras = ["stt"], marker = "extra == 'all'" },
     { name = "edge-tts", marker = "extra == 'edge'", specifier = ">=7.2.8" },
+    { name = "httpx", marker = "extra == 'see'", specifier = ">=0.27" },
     { name = "mss", marker = "extra == 'see'", specifier = ">=9.0.0" },
     { name = "pillow", marker = "extra == 'see'", specifier = ">=10.0.0" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.2.0" },


### PR DESCRIPTION
## Summary

Phase 1 of the B4 plan — adds a second VLM engine that talks to \`llama-server\` over HTTP. User manages the server lifecycle themselves in this PR; lazy auto-spawn (Phase 2) and SessionStart preload (Phase 3) land in stacked follow-ups.

### Why this matters

- **Genuinely warm latency** across \`/see\` calls. The in-process engine looks fast on paper (\`~200-500 ms warm\`) but \`/see\` spawns a fresh Python process per invocation, so the model reloads (3-5 s) every time. \`llama-server\` keeps the model resident.
- **Unblocks SmolVLM2-2.2B and Qwen3-VL-2B** today without waiting for \`abetlen/llama-cpp-python\` to ship chat handlers (upstream issue #2080 for Qwen3-VL; SmolVLM2 has no handler upstream at all).

## What changed

- \`src/cc_vlm/engine.py\` — new \`LlamaServerVLMEngine\` class: \`available()\` via \`GET /health\` (2s timeout), \`describe()\` via base64-data-URL POST to \`/v1/chat/completions\`. Engine accepts \`**kwargs\` to absorb forwarded irrelevant args. \`_ENGINE_TYPES\` extended; \`_unavailable_message\` widened with per-engine branches.
- \`src/cc_vlm/config.py\` — six new \`VLMConfig\` fields (\`server_url\`, \`server_model_alias\` functional now; \`server_port\`, \`server_binary\`, \`auto_spawn\`, \`preload\` inert until Phase 2/3).
- \`src/cc_vlm/__main__.py\` — forward two new kwargs to \`resolve_vlm_engine\`.
- \`pyproject.toml\` — \`httpx>=0.27\` added to \`[see]\` extras.
- \`.cc-senses.example.toml\` — documents all six new fields.
- \`tests/test_vlm_engine.py\` — new \`TestLlamaServerVLMEngine*\` classes mirroring the existing in-process test structure; new \`mock_httpx\` fixture.
- \`tests/test_vlm_config.py\` — defaults + env-override tests for the six new fields.
- Docs: \`architecture.md\` table updated with both engines; \`landscape.md\` row moved from Considered/deferred to Shipped; \`skills/see/SKILL.md\` gains an \"Engines\" overview + \"Using a llama-server backend (manual)\" section.

## Configuration example

\`\`\`toml
[vlm]
engine = \"llamaserver\"
server_url = \"http://localhost:8080\"
\`\`\`

Plus the user runs:
\`\`\`bash
llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
\`\`\`

## Non-goals (this PR)

- No lazy auto-spawn — that's Phase 2 (PR 2 of the stack).
- No SessionStart preload — that's Phase 3 (PR 3).
- No version bump — version bump consolidated in PR 3 to land all three phases under one \`0.9.0\` release.

## Test plan

- [ ] CI: lint/markdown + lint/links + CodeQL green
- [ ] \`make validate\` locally (sandbox blocked uv cache; ran tests + lint manually)
- [ ] Manual smoke: start \`llama-server -m SmolVLM2.gguf --mmproj SmolVLM2-mmproj.gguf --port 8080\`; set \`[vlm] engine = \"llamaserver\"\` + \`server_url = \"http://localhost:8080\"\`; \`uv run python -m cc_vlm --image-file /tmp/screenshot.png\` returns text
- [ ] Backwards-compat smoke: with \`server_url\` unset + \`model_path\`/\`mmproj_path\` set, in-process engine still wins (priority order preserved)

Closes #101.

Generated with Claude <noreply@anthropic.com>