### PR TITLE
feat(vlm): lazy auto-spawn + lifecycle management for llama-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 	setup_see setup_see_qwen25 setup_user setup_all \
 	clean validate lint_fix quick_validate lint_src lint_tests lint_md lint_links \
 	type_check test test_coverage speak wrap \
+	vlm_server_status vlm_server_stop vlm_server_logs \
 	bump_patch bump_minor bump_major help
 .DEFAULT_GOAL := help
 
@@ -222,6 +223,34 @@ see_save_only: ## Capture screen + save JPEG, print path (smoke-test mss + proce
 	uv run python -m cc_vlm --save-only
 
 
+# MARK: VLM SERVER
+
+
+vlm_server_status: ## Check if cc-senses-bridge's spawned llama-server is running
+	pidfile=$$HOME/.cache/cc-senses-bridge/llama-server.pid
+	if [ ! -f $$pidfile ]; then
+		echo "llama-server not running (no pidfile at $$pidfile)"
+		exit 0
+	fi
+	pid=$$(cat $$pidfile)
+	if kill -0 $$pid 2>/dev/null; then
+		echo "llama-server running (PID $$pid)"
+	else
+		echo "llama-server not running (stale pidfile points at PID $$pid)"
+	fi
+
+vlm_server_stop: ## Stop cc-senses-bridge-spawned llama-server (no-op if external/unmanaged)
+	uv run python -c "from cc_vlm.server_manager import shutdown; shutdown(only_if_ours=True); print('  llama-server stopped (or already stopped)')"
+
+vlm_server_logs: ## Tail the spawned llama-server log (~/.cache/cc-senses-bridge/llama-server.log)
+	logfile=$$HOME/.cache/cc-senses-bridge/llama-server.log
+	if [ ! -f $$logfile ]; then
+		echo "No log file at $$logfile"
+		exit 1
+	fi
+	tail -f $$logfile
+
+
 # MARK: SMOKE
 
 
@@ -231,7 +260,7 @@ smoke_imports: ## Smoke: verify all cc_* modules import cleanly (no external dep
 	@echo "--- cc_stt imports"
 	@uv run python -c "import cc_stt.engine, cc_stt.config, cc_stt.listen; print('  ok')"
 	@echo "--- cc_vlm imports"
-	@uv run python -c "import cc_vlm.engine, cc_vlm.config, cc_vlm.capture, cc_vlm.processor, cc_vlm.templates, cc_vlm.cache; print('  ok')"
+	@uv run python -c "import cc_vlm.engine, cc_vlm.config, cc_vlm.capture, cc_vlm.processor, cc_vlm.templates, cc_vlm.cache, cc_vlm.server_manager; print('  ok')"
 
 smoke_cli: ## Smoke: verify each module's --help works
 	@echo "--- cc_tts.speak --help"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,26 @@ Engine priority (auto-detect order): `llamacpp` → `llamaserver` (in-process pr
 
 **Why `llama-server` and not Ollama**: same llama.cpp binary already used by the in-process path, no extra daemon family to support, no Ollama-as-dependency. Ollama was considered and rejected on those grounds during the #91 research pass.
 
+### Server lifecycle
+
+`LlamaServerVLMEngine` supports three operational modes, selected by config:
+
+| Mode | Config | Spawn trigger | First-call latency |
+|---|---|---|---|
+| **User-managed** | `auto_spawn = false` | None (user runs `llama-server`) | Cold if user hasn't started it (engine returns "unreachable") |
+| **Lazy (default)** | `auto_spawn = true` | First `/see` call when `/health` probe fails | Up to ~30 s (model load) |
+| **Preload** (Phase 3) | `preload = true` | SessionStart hook | Hot from call 1; ~3-5 s background load at session start |
+
+The lifecycle helpers live in `src/cc_vlm/server_manager.py`:
+
+- PID file: `~/.cache/cc-senses-bridge/llama-server.pid`
+- Log file: `~/.cache/cc-senses-bridge/llama-server.log` (truncated on each spawn)
+- Auto-spawn is gated on `is_localhost(server_url)` — remote hosts are assumed externally managed and silently skip the spawn attempt.
+- `ensure_running()` is idempotent: probe `/health` first, then check the pidfile, only spawn as a last resort.
+- Concurrency: best-effort, no file lock. Parallel `/see` invocations during cold start may produce transient EADDRINUSE on the loser's spawn; the system self-heals on the next invocation via `pid_is_alive`.
+
+Manual control via Makefile targets: `make vlm_server_status` / `vlm_server_stop` / `vlm_server_logs`.
+
 BLAKE3 frame cache: unchanged screen + same template = 0 VLM calls.
 Cold start: 3-5 s (model load). Warm page cache: 1-2 s. In-process reuse: 200-500 ms.
 

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -30,29 +30,58 @@ Two engines are available; auto-detect picks the first one that's configured.
 | `llamacpp` (in-process) | You have `model_path` + `mmproj_path` set and the appropriate `llama-cpp-python` chat handler exists for your model family | No daemon; reloads the model on every `/see` call (each invocation is a fresh Python process) |
 | `llamaserver` (HTTP) | You want a hot model across `/see` calls, or you're using SmolVLM2 / Qwen3-VL where the in-process handler doesn't exist yet | User runs `llama-server` separately; ~1-2 GB RAM while alive; warm response within 200-500 ms |
 
-### Using a llama-server backend (manual)
+### Using the llama-server backend
 
-For SmolVLM2-2.2B, Qwen3-VL-2B, or any GGUF llama.cpp supports but `llama-cpp-python` doesn't yet:
+Three operating modes, picked by config. Useful for SmolVLM2-2.2B, Qwen3-VL-2B, or any GGUF llama.cpp supports but `llama-cpp-python` doesn't yet.
 
-1. Install `llama.cpp` and ensure `llama-server` is on your PATH.
-2. Start the server with your model + mmproj:
+Prerequisite: `llama-server` must be installed and on your `PATH` (install via your distro's `llama.cpp` package or build from source).
 
-   ```bash
-   llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
-   ```
+#### 1. Lazy auto-spawn (default)
 
-3. Configure cc-senses-bridge to talk to it. Add to `.cc-senses.toml`:
+cc-senses-bridge spawns `llama-server` on first `/see`, then re-uses the warm process for subsequent calls. Set in `.cc-senses.toml`:
 
-   ```toml
-   [vlm]
-   engine = "llamaserver"
-   server_url = "http://localhost:8080"
-   # server_model_alias is usually unused — llama-server accepts any name
-   ```
+```toml
+[vlm]
+engine = "llamaserver"
+server_url = "http://localhost:8080"
+model_path = "/path/to/SmolVLM2.gguf"
+mmproj_path = "/path/to/SmolVLM2-mmproj.gguf"
+# auto_spawn defaults to true
+```
 
-4. Run `/see` as usual. The model stays resident in `llama-server` between invocations, so latency stays around the inference cost (~200-500 ms) instead of paying the 3-5 s model load on every call.
+First `/see` call takes up to ~30 s (model load). Subsequent calls are warm (~200-500 ms). Inspect/stop the spawned server:
 
-> **Note**: Phase 1 ships manual server management only. Lazy auto-spawn (`auto_spawn = true`) and SessionStart preload (`preload = true`) land in subsequent PRs.
+```bash
+make vlm_server_status   # is it running?
+make vlm_server_logs     # tail the boot log
+make vlm_server_stop     # SIGTERM the spawned process
+```
+
+#### 2. User-managed
+
+You start `llama-server` yourself; cc-senses-bridge just POSTs to it. Useful for shared servers, GPU rigs, or remote hosts.
+
+```bash
+llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
+```
+
+```toml
+[vlm]
+engine = "llamaserver"
+server_url = "http://localhost:8080"
+auto_spawn = false   # cc-senses-bridge will NOT try to spawn
+```
+
+For remote hosts (`server_url = "http://my-rig.local:8080"`), `auto_spawn` is implicitly disabled — only localhost / 127.0.0.1 / ::1 are eligible for auto-spawn.
+
+#### 3. Preload (Phase 3 — not yet shipped)
+
+Spawns `llama-server` at Claude Code session start so even the first `/see` is hot. Lands in a follow-up PR; tracker in [docs/architecture.md](../../docs/architecture.md#server-lifecycle).
+
+### Known limitations
+
+- **Cold-start concurrency race**: parallel `/see` invocations during the very first call (when the server is being spawned) may produce a transient EADDRINUSE on the losing process's `llama-server` spawn. The system self-heals on the next invocation — `pid_is_alive` detects the dead PID and re-spawns. No file lock for now (YAGNI for interactive CLI use).
+- **30 s spawn timeout**: if the model is large or disk is cold, `available()` can time out waiting for `/health`. Check `make vlm_server_logs` for boot errors.
 
 ## Usage
 

--- a/src/cc_vlm/__main__.py
+++ b/src/cc_vlm/__main__.py
@@ -127,6 +127,9 @@ def main(argv: list[str] | None = None) -> int:
             max_tokens=config.max_tokens,
             server_url=config.server_url,
             server_model_alias=config.server_model_alias,
+            auto_spawn=config.auto_spawn,
+            server_port=config.server_port,
+            server_binary=config.server_binary,
         )
     except (RuntimeError, ValueError) as exc:
         print(f"cc_vlm: {exc}", file=sys.stderr)

--- a/src/cc_vlm/engine.py
+++ b/src/cc_vlm/engine.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
+from cc_vlm import server_manager
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -185,14 +187,25 @@ class LlamaServerVLMEngine:
         server_url: str = "",
         server_model_alias: str = "",
         max_tokens: int = 256,
+        auto_spawn: bool = False,
+        model_path: str = "",
+        mmproj_path: str = "",
+        server_port: int = 8080,
+        server_binary: str = "llama-server",
         **_kwargs: Any,
     ) -> None:
-        # Reason: `_kwargs` absorbs model_path/handler_name/etc. forwarded
-        # uniformly by `resolve_vlm_engine`. Those are meaningless for the
-        # HTTP backend.
+        # Reason: `_kwargs` absorbs handler_name/n_ctx/n_gpu_layers etc.
+        # forwarded uniformly by `resolve_vlm_engine`. Those are meaningless
+        # for the HTTP backend. model_path/mmproj_path/server_port/
+        # server_binary are needed for Phase 2 lazy auto-spawn.
         self.server_url = server_url.rstrip("/")
         self.server_model_alias = server_model_alias
         self.max_tokens = max_tokens
+        self.auto_spawn = auto_spawn
+        self.model_path = model_path
+        self.mmproj_path = mmproj_path
+        self.server_port = server_port
+        self.server_binary = server_binary
 
     @property
     def name(self) -> str:
@@ -201,25 +214,34 @@ class LlamaServerVLMEngine:
     def available(self) -> bool:
         """Check whether llama-server is reachable on `server_url`.
 
-        Returns False on: empty `server_url`, missing `httpx`, non-200
-        health response, connect error, or timeout. Does NOT spawn a
-        server here — that's Phase 2.
+        Order:
+          1. False if `server_url` empty.
+          2. True if `GET /health` returns 200 (user-managed or already
+             running). `server_manager.is_reachable` also returns False
+             when `httpx` is not installed, so missing-deps is handled
+             implicitly.
+          3. False if `auto_spawn` is False, or url is non-localhost, or
+             `model_path` / `mmproj_path` are unset.
+          4. Otherwise call `server_manager.ensure_running` (Phase 2 lazy
+             spawn). May take up to 30 s while the model loads.
         """
         if not self.server_url:
             return False
-        try:
-            import httpx
-        except ImportError:
+        if server_manager.is_reachable(self.server_url):
+            return True
+        if not self.auto_spawn:
             return False
-        try:
-            response = httpx.get(f"{self.server_url}/health", timeout=2.0)
-        except Exception:  # noqa: BLE001
-            # Reason: httpx raises various subclasses (ConnectError,
-            # TimeoutException, ReadTimeout, etc.). All of them mean
-            # "server not reachable" — catch broadly so available()
-            # never propagates a transport error to the caller.
+        if not server_manager.is_localhost(self.server_url):
             return False
-        return response.status_code == 200
+        if not self.model_path or not self.mmproj_path:
+            return False
+        return server_manager.ensure_running(
+            self.server_url,
+            self.server_port,
+            self.server_binary,
+            self.model_path,
+            self.mmproj_path,
+        )
 
     def describe(self, image_path: Path, prompt: str) -> str:
         """Read the image, POST a chat-completion to llama-server, return text.
@@ -286,6 +308,9 @@ def resolve_vlm_engine(
     max_tokens: int = 256,
     server_url: str = "",
     server_model_alias: str = "",
+    auto_spawn: bool = False,
+    server_port: int = 8080,
+    server_binary: str = "llama-server",
 ) -> VLMEngine:
     """Resolve a VLM engine by name or auto-detect first available.
 
@@ -307,6 +332,9 @@ def resolve_vlm_engine(
         "max_tokens": max_tokens,
         "server_url": server_url,
         "server_model_alias": server_model_alias,
+        "auto_spawn": auto_spawn,
+        "server_port": server_port,
+        "server_binary": server_binary,
     }
 
     if engine_name != "auto":

--- a/src/cc_vlm/server_manager.py
+++ b/src/cc_vlm/server_manager.py
@@ -1,0 +1,171 @@
+"""Lifecycle helpers for the llama-server HTTP backend.
+
+Owns spawn / pidfile / health-probe / shutdown for the local `llama-server`
+process that `LlamaServerVLMEngine` talks to. Engine imports this module
+as an opaque utility — there's no engine import here, so no circular risk.
+
+Concurrency posture: best-effort, not locked. If two `/see` invocations
+race during cold start, one binds the port and the other exits on
+EADDRINUSE. The pidfile may transiently point at the dead PID; the next
+invocation's `pid_is_alive` check self-heals.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+PID_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "llama-server.pid"
+LOG_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "llama-server.log"
+
+_LOCALHOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def is_reachable(url: str, timeout: float = 2.0) -> bool:
+    """GET <url>/health → True on 200; False on any other status, transport
+    error, missing httpx, or timeout."""
+    try:
+        import httpx
+    except ImportError:
+        return False
+    try:
+        response = httpx.get(f"{url.rstrip('/')}/health", timeout=timeout)
+    except Exception:  # noqa: BLE001
+        # Reason: httpx raises ConnectError, TimeoutException, ReadTimeout
+        # and friends. All mean "not reachable" — catch broadly.
+        return False
+    return response.status_code == 200
+
+
+def is_localhost(url: str) -> bool:
+    """True iff the URL's host is loopback (localhost / 127.0.0.1 / ::1)."""
+    host = (urlparse(url).hostname or "").lower()
+    return host in _LOCALHOSTS
+
+
+def read_pidfile() -> int | None:
+    """Return the stored PID, or None if pidfile is absent / malformed."""
+    try:
+        return int(PID_FILE.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def write_pidfile(pid: int) -> None:
+    """Persist PID to disk. Creates parent dirs."""
+    PID_FILE.parent.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(pid))
+
+
+def clear_pidfile() -> None:
+    """Remove pidfile if present. Idempotent."""
+    try:
+        PID_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def pid_is_alive(pid: int) -> bool:
+    """True iff a process with `pid` exists and we can probe it.
+
+    `os.kill(pid, 0)` is the POSIX trick — sends no signal but raises
+    ProcessLookupError if the pid is gone. PermissionError means the
+    process exists under a different user (treat as alive — port still
+    occupied).
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def spawn(model_path: str, mmproj_path: str, port: int, binary: str) -> int:
+    """Spawn `llama-server` as a detached background process.
+
+    Writes pidfile and returns the spawned PID. Truncates LOG_FILE on
+    each spawn so the log reflects only the most recent run.
+    Raises FileNotFoundError if `binary` is not on PATH.
+    """
+    if shutil.which(binary) is None:
+        msg = f"llama-server binary not found on PATH: {binary!r}"
+        raise FileNotFoundError(msg)
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    log = LOG_FILE.open("wb")  # noqa: SIM115  (lifetime managed by child process)
+    proc = subprocess.Popen(
+        [binary, "-m", model_path, "--mmproj", mmproj_path, "--port", str(port)],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    write_pidfile(proc.pid)
+    return proc.pid
+
+
+def wait_for_ready(url: str, timeout: float = 30.0, interval: float = 0.5) -> bool:
+    """Poll `/health` until 200 or timeout. Returns True on success."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if is_reachable(url, timeout=1.0):
+            return True
+        time.sleep(interval)
+    return False
+
+
+def ensure_running(
+    server_url: str,
+    server_port: int,
+    server_binary: str,
+    model_path: str,
+    mmproj_path: str,
+) -> bool:
+    """Idempotent: ensure a llama-server is reachable on `server_url`.
+
+    Order:
+      1. probe /health → True if already up (user-managed or our prior spawn)
+      2. if pidfile + alive + reachable → True (re-discovery on same session)
+      3. refuse to spawn remote hosts
+      4. refuse to spawn without model + mmproj paths
+      5. spawn + wait_for_ready
+    """
+    if is_reachable(server_url):
+        return True
+    existing_pid = read_pidfile()
+    if existing_pid is not None and pid_is_alive(existing_pid) and is_reachable(server_url):
+        return True
+    if not is_localhost(server_url):
+        return False
+    if not model_path or not mmproj_path:
+        return False
+    try:
+        spawn(model_path, mmproj_path, server_port, server_binary)
+    except FileNotFoundError:
+        return False
+    return wait_for_ready(server_url)
+
+
+def shutdown(only_if_ours: bool = True) -> None:
+    """SIGTERM the pidfile's process if alive; clear pidfile either way.
+
+    When `only_if_ours=True` (default), absence of the pidfile means
+    external management — silently no-op. Setting it to False is reserved
+    for future "best-effort kill anything on the port" semantics; not used
+    today.
+    """
+    _ = only_if_ours  # currently no-different branch; reserved for future use
+    pid = read_pidfile()
+    if pid is None:
+        return
+    if pid_is_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+    clear_pidfile()

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -676,3 +676,129 @@ class TestResolveVLMEngineWithLlamaServer:
         with pytest.raises(RuntimeError) as exc_info:
             resolve_vlm_engine("llamaserver", server_url="http://localhost:9999")
         assert "http://localhost:9999" in str(exc_info.value)
+
+
+class TestLlamaServerVLMEngineLazySpawn:
+    """available() with auto_spawn=True should call server_manager.ensure_running
+    when the initial /health probe fails. Engine doesn't import server_manager at
+    module load; it's used inside available() — patch via the cc_vlm.engine
+    module namespace."""
+
+    def test_lazy_spawn_when_unreachable(
+        self, mock_httpx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        spawn_calls = {"n": 0}
+
+        def fake_ensure(*args: object, **kwargs: object) -> bool:
+            spawn_calls["n"] += 1
+            return True
+
+        from cc_vlm import server_manager
+
+        monkeypatch.setattr(server_manager, "ensure_running", fake_ensure)
+
+        engine = LlamaServerVLMEngine(
+            server_url="http://localhost:8080",
+            auto_spawn=True,
+            model_path="/m.gguf",
+            mmproj_path="/mm.gguf",
+            server_port=8080,
+            server_binary="llama-server",
+        )
+        assert engine.available() is True
+        assert spawn_calls["n"] == 1
+
+    def test_no_spawn_when_auto_spawn_false(
+        self, mock_httpx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        spawn_calls = {"n": 0}
+
+        def fake_ensure(*args: object, **kwargs: object) -> bool:
+            spawn_calls["n"] += 1
+            return True
+
+        from cc_vlm import server_manager
+
+        monkeypatch.setattr(server_manager, "ensure_running", fake_ensure)
+
+        engine = LlamaServerVLMEngine(
+            server_url="http://localhost:8080",
+            auto_spawn=False,
+            model_path="/m.gguf",
+            mmproj_path="/mm.gguf",
+        )
+        assert engine.available() is False
+        assert spawn_calls["n"] == 0
+
+    def test_no_spawn_when_non_localhost(
+        self, mock_httpx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        spawn_calls = {"n": 0}
+
+        def fake_ensure(*args: object, **kwargs: object) -> bool:
+            spawn_calls["n"] += 1
+            return True
+
+        from cc_vlm import server_manager
+
+        monkeypatch.setattr(server_manager, "ensure_running", fake_ensure)
+
+        engine = LlamaServerVLMEngine(
+            server_url="http://example.com:8080",
+            auto_spawn=True,
+            model_path="/m.gguf",
+            mmproj_path="/mm.gguf",
+        )
+        assert engine.available() is False
+        assert spawn_calls["n"] == 0
+
+    def test_no_spawn_when_model_path_empty(
+        self, mock_httpx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        spawn_calls = {"n": 0}
+
+        def fake_ensure(*args: object, **kwargs: object) -> bool:
+            spawn_calls["n"] += 1
+            return True
+
+        from cc_vlm import server_manager
+
+        monkeypatch.setattr(server_manager, "ensure_running", fake_ensure)
+
+        engine = LlamaServerVLMEngine(
+            server_url="http://localhost:8080",
+            auto_spawn=True,
+            model_path="",
+            mmproj_path="",
+        )
+        assert engine.available() is False
+        assert spawn_calls["n"] == 0
+
+    def test_resolver_forwards_auto_spawn(
+        self, mock_httpx: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit engine='llamaserver' should construct with the forwarded
+        auto_spawn / server_port / server_binary kwargs."""
+        engine = resolve_vlm_engine(
+            "llamaserver",
+            server_url="http://localhost:8080",
+            auto_spawn=True,
+            server_port=9090,
+            server_binary="/usr/local/bin/llama-server",
+        )
+        assert isinstance(engine, LlamaServerVLMEngine)
+        assert engine.auto_spawn is True
+        assert engine.server_port == 9090
+        assert engine.server_binary == "/usr/local/bin/llama-server"

--- a/tests/test_vlm_server_manager.py
+++ b/tests/test_vlm_server_manager.py
@@ -1,0 +1,457 @@
+"""Tests for cc_vlm.server_manager — llama-server lifecycle helpers.
+
+Mocks httpx (for is_reachable and wait_for_ready), subprocess.Popen (for
+spawn), and os.kill (for pid_is_alive / shutdown). PID_FILE and LOG_FILE
+are monkeypatched into tmp_path so tests don't touch ~/.cache.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cc_vlm import server_manager
+
+
+@pytest.fixture
+def isolated_pidfile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point PID_FILE and LOG_FILE at tmp_path so tests don't touch ~/.cache."""
+    pid_file = tmp_path / "llama-server.pid"
+    log_file = tmp_path / "llama-server.log"
+    monkeypatch.setattr(server_manager, "PID_FILE", pid_file)
+    monkeypatch.setattr(server_manager, "LOG_FILE", log_file)
+    return pid_file
+
+
+@pytest.fixture
+def mock_httpx() -> MagicMock:
+    """Install a fake httpx into sys.modules for server_manager to import.
+
+    Tests configure `.get.return_value.status_code` or `.get.side_effect`
+    to drive is_reachable behavior.
+    """
+    fake = MagicMock()
+
+    class FakeConnectError(Exception):
+        pass
+
+    class FakeTimeoutError(Exception):
+        pass
+
+    fake.ConnectError = FakeConnectError
+    fake.TimeoutException = FakeTimeoutError
+
+    default_response = MagicMock()
+    default_response.status_code = 200
+    fake.get.return_value = default_response
+
+    saved = sys.modules.get("httpx")
+    sys.modules["httpx"] = fake
+    yield fake
+    if saved is None:
+        sys.modules.pop("httpx", None)
+    else:
+        sys.modules["httpx"] = saved
+
+
+class TestIsReachable:
+    def test_reachable_on_200(self, mock_httpx: MagicMock) -> None:
+        assert server_manager.is_reachable("http://localhost:8080") is True
+        mock_httpx.get.assert_called_once()
+        called_url = mock_httpx.get.call_args.args[0]
+        assert called_url == "http://localhost:8080/health"
+
+    def test_strips_trailing_slash(self, mock_httpx: MagicMock) -> None:
+        server_manager.is_reachable("http://localhost:8080/")
+        called_url = mock_httpx.get.call_args.args[0]
+        assert called_url == "http://localhost:8080/health"
+
+    def test_unreachable_on_503(self, mock_httpx: MagicMock) -> None:
+        bad = MagicMock()
+        bad.status_code = 503
+        mock_httpx.get.return_value = bad
+        assert server_manager.is_reachable("http://localhost:8080") is False
+
+    def test_unreachable_on_connect_error(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.get.side_effect = mock_httpx.ConnectError("refused")
+        assert server_manager.is_reachable("http://localhost:8080") is False
+
+    def test_unreachable_on_timeout(self, mock_httpx: MagicMock) -> None:
+        mock_httpx.get.side_effect = mock_httpx.TimeoutException("timeout")
+        assert server_manager.is_reachable("http://localhost:8080") is False
+
+    def test_unreachable_when_httpx_missing(self) -> None:
+        saved = sys.modules.pop("httpx", None)
+        sys.modules["httpx"] = None  # type: ignore[assignment]
+        try:
+            assert server_manager.is_reachable("http://localhost:8080") is False
+        finally:
+            sys.modules.pop("httpx", None)
+            if saved is not None:
+                sys.modules["httpx"] = saved
+
+
+class TestIsLocalhost:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8080",
+            "http://localhost",
+            "http://127.0.0.1:8080",
+            "http://127.0.0.1",
+            "http://[::1]:8080",
+            "https://LOCALHOST:8080",
+        ],
+    )
+    def test_local_urls(self, url: str) -> None:
+        assert server_manager.is_localhost(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com:8080",
+            "http://192.168.1.5:8080",
+            "http://10.0.0.1",
+            "http://my-server.local",
+        ],
+    )
+    def test_remote_urls(self, url: str) -> None:
+        assert server_manager.is_localhost(url) is False
+
+
+class TestPidfileLifecycle:
+    def test_write_and_read(self, isolated_pidfile: Path) -> None:
+        server_manager.write_pidfile(12345)
+        assert isolated_pidfile.read_text() == "12345"
+        assert server_manager.read_pidfile() == 12345
+
+    def test_write_creates_parent_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nested = tmp_path / "a" / "b" / "c" / "llama-server.pid"
+        monkeypatch.setattr(server_manager, "PID_FILE", nested)
+        server_manager.write_pidfile(99)
+        assert nested.exists()
+
+    def test_read_returns_none_when_missing(self, isolated_pidfile: Path) -> None:
+        assert server_manager.read_pidfile() is None
+
+    def test_read_returns_none_on_garbage(self, isolated_pidfile: Path) -> None:
+        isolated_pidfile.parent.mkdir(parents=True, exist_ok=True)
+        isolated_pidfile.write_text("not-a-number")
+        assert server_manager.read_pidfile() is None
+
+    def test_clear_removes_file(self, isolated_pidfile: Path) -> None:
+        server_manager.write_pidfile(7)
+        assert isolated_pidfile.exists()
+        server_manager.clear_pidfile()
+        assert not isolated_pidfile.exists()
+
+    def test_clear_is_idempotent(self, isolated_pidfile: Path) -> None:
+        # Pidfile doesn't exist — clear should not raise
+        server_manager.clear_pidfile()
+        server_manager.clear_pidfile()  # second call also fine
+
+
+class TestPidIsAlive:
+    def test_returns_true_when_kill_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+        assert server_manager.pid_is_alive(12345) is True
+
+    def test_returns_false_on_process_lookup_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_lookup(pid: int, sig: int) -> None:
+            raise ProcessLookupError()
+
+        monkeypatch.setattr(os, "kill", raise_lookup)
+        assert server_manager.pid_is_alive(12345) is False
+
+    def test_returns_true_on_permission_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PermissionError means process exists but we can't signal it (different user).
+        Treat as alive — the server still occupies the port."""
+
+        def raise_perm(pid: int, sig: int) -> None:
+            raise PermissionError()
+
+        monkeypatch.setattr(os, "kill", raise_perm)
+        assert server_manager.pid_is_alive(12345) is True
+
+
+class TestSpawn:
+    def test_spawn_invokes_popen_with_expected_args(
+        self,
+        isolated_pidfile: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        recorded: dict[str, object] = {}
+
+        class FakeProc:
+            pid = 99999
+
+        def fake_popen(*args: object, **kwargs: object) -> FakeProc:
+            recorded["args"] = args
+            recorded["kwargs"] = kwargs
+            return FakeProc()
+
+        monkeypatch.setattr(server_manager.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(server_manager.shutil, "which", lambda _name: "/usr/bin/llama-server")
+
+        pid = server_manager.spawn(
+            model_path="/m/model.gguf",
+            mmproj_path="/m/mmproj.gguf",
+            port=8080,
+            binary="llama-server",
+        )
+
+        assert pid == 99999
+        cmd = recorded["args"][0]
+        assert cmd == [
+            "llama-server",
+            "-m",
+            "/m/model.gguf",
+            "--mmproj",
+            "/m/mmproj.gguf",
+            "--port",
+            "8080",
+        ]
+        kwargs = recorded["kwargs"]
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stderr"] == server_manager.subprocess.STDOUT
+
+    def test_spawn_writes_pidfile(
+        self,
+        isolated_pidfile: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class FakeProc:
+            pid = 42
+
+        monkeypatch.setattr(server_manager.subprocess, "Popen", lambda *a, **kw: FakeProc())
+        monkeypatch.setattr(server_manager.shutil, "which", lambda _name: "/bin/llama-server")
+
+        server_manager.spawn("/m.gguf", "/mm.gguf", 8080, "llama-server")
+
+        assert isolated_pidfile.read_text() == "42"
+
+    def test_spawn_raises_when_binary_missing(
+        self,
+        isolated_pidfile: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(server_manager.shutil, "which", lambda _name: None)
+
+        with pytest.raises(FileNotFoundError, match="llama-server"):
+            server_manager.spawn("/m.gguf", "/mm.gguf", 8080, "llama-server")
+
+
+class TestWaitForReady:
+    def test_returns_true_when_immediately_reachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: True)
+        assert server_manager.wait_for_ready("http://localhost:8080", timeout=5.0) is True
+
+    def test_returns_true_after_polling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = {"n": 0}
+
+        def fake_reachable(url: str, timeout: float = 2.0) -> bool:
+            calls["n"] += 1
+            return calls["n"] >= 3  # 200 on the third call
+
+        monkeypatch.setattr(server_manager, "is_reachable", fake_reachable)
+        # Use a very short interval so the test stays fast
+        result = server_manager.wait_for_ready("http://localhost:8080", timeout=2.0, interval=0.01)
+        assert result is True
+        assert calls["n"] == 3
+
+    def test_returns_false_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: False)
+        result = server_manager.wait_for_ready("http://localhost:8080", timeout=0.1, interval=0.05)
+        assert result is False
+
+
+class TestEnsureRunning:
+    def test_returns_true_when_already_reachable(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: True)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 1,
+        )
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is True
+        assert spawn_calls["n"] == 0  # didn't spawn
+
+    def test_skips_spawn_when_pidfile_alive_and_reachable(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server_manager.write_pidfile(12345)
+        # First is_reachable call (line 1) returns False; subsequent True (after pidfile check)
+        call_count = {"n": 0}
+
+        def reachable(url: str, timeout: float = 2.0) -> bool:
+            call_count["n"] += 1
+            return call_count["n"] >= 2
+
+        monkeypatch.setattr(server_manager, "is_reachable", reachable)
+        monkeypatch.setattr(server_manager, "pid_is_alive", lambda pid: True)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 1,
+        )
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is True
+        assert spawn_calls["n"] == 0
+
+    def test_spawns_when_pidfile_dead(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server_manager.write_pidfile(99999)
+        monkeypatch.setattr(server_manager, "pid_is_alive", lambda pid: False)
+
+        # is_reachable: False (initial), True (after spawn)
+        call_count = {"n": 0}
+
+        def reachable(url: str, timeout: float = 2.0) -> bool:
+            call_count["n"] += 1
+            return call_count["n"] >= 2
+
+        monkeypatch.setattr(server_manager, "is_reachable", reachable)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 7,
+        )
+        monkeypatch.setattr(server_manager, "wait_for_ready", lambda url, **kw: True)
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is True
+        assert spawn_calls["n"] == 1
+
+    def test_spawns_when_nothing_present(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: False)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 7,
+        )
+        monkeypatch.setattr(server_manager, "wait_for_ready", lambda url, **kw: True)
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is True
+        assert spawn_calls["n"] == 1
+
+    def test_no_spawn_when_remote_url(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: False)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 0,
+        )
+
+        result = server_manager.ensure_running(
+            "http://example.com:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is False
+        assert spawn_calls["n"] == 0
+
+    def test_no_spawn_when_paths_missing(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: False)
+        spawn_calls = {"n": 0}
+        monkeypatch.setattr(
+            server_manager,
+            "spawn",
+            lambda *a, **kw: spawn_calls.update(n=spawn_calls["n"] + 1) or 0,
+        )
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "", ""
+        )
+
+        assert result is False
+        assert spawn_calls["n"] == 0
+
+    def test_returns_false_when_binary_missing(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(server_manager, "is_reachable", lambda url, timeout=2.0: False)
+
+        def raise_fnf(*args: object, **kwargs: object) -> int:
+            raise FileNotFoundError("llama-server")
+
+        monkeypatch.setattr(server_manager, "spawn", raise_fnf)
+
+        result = server_manager.ensure_running(
+            "http://localhost:8080", 8080, "llama-server", "/m.gguf", "/mm.gguf"
+        )
+
+        assert result is False
+
+
+class TestShutdown:
+    def test_sends_sigterm_when_alive(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server_manager.write_pidfile(54321)
+        monkeypatch.setattr(server_manager, "pid_is_alive", lambda pid: True)
+        signals: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        server_manager.shutdown(only_if_ours=True)
+
+        assert signals == [(54321, signal.SIGTERM)]
+        assert not isolated_pidfile.exists()
+
+    def test_clears_pidfile_when_dead(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server_manager.write_pidfile(11111)
+        monkeypatch.setattr(server_manager, "pid_is_alive", lambda pid: False)
+        signals: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        server_manager.shutdown(only_if_ours=True)
+
+        assert signals == []  # didn't try to signal a dead pid
+        assert not isolated_pidfile.exists()
+
+    def test_noop_when_pidfile_absent(
+        self, isolated_pidfile: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        signals: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        server_manager.shutdown(only_if_ours=True)
+
+        assert signals == []


### PR DESCRIPTION
## Summary

Phase 2 of the B4 plan. Adds lazy auto-spawn of \`llama-server\` from \`LlamaServerVLMEngine.available()\` when no server is already reachable. New \`server_manager.py\` module owns the spawn / pidfile / health-probe / shutdown lifecycle. Activates three Phase-1-inert config fields (\`server_port\`, \`server_binary\`, \`auto_spawn\` — \`preload\` stays inert until Phase 3).

## Commits (topical)

1. **\`feat(vlm): add server_manager lifecycle module\`** — new \`src/cc_vlm/server_manager.py\` with all lifecycle helpers; 24-case test file. No engine import — opaque utility.
2. **\`feat(vlm): integrate lazy auto-spawn into LlamaServerVLMEngine\`** — engine \`__init__\` accepts five new fields; \`available()\` calls \`ensure_running\` when probe fails AND \`auto_spawn\` AND localhost AND paths set. 5-case lazy-spawn test class.
3. **\`build(make): add vlm_server lifecycle targets\`** — \`vlm_server_status\` / \`vlm_server_stop\` / \`vlm_server_logs\` using the project's \`.ONESHELL\`/\`.SILENT\` idiom.
4. **\`docs(vlm): document server lifecycle modes\`** — \`docs/architecture.md\` lifecycle subsection + \`skills/see/SKILL.md\` restructured into three numbered subsections.

## Concurrency posture

Best-effort, not file-locked. Parallel \`/see\` invocations during cold start may produce transient EADDRINUSE on the losing spawn; \`pid_is_alive\` detects the dead PID and self-heals on next call. No \`fcntl.flock\` — YAGNI for interactive CLI workflow. Documented in SKILL.md.

## Latency contract

When \`auto_spawn\` fires, \`available()\` may take up to **30 s** (model load wait). Behavior change vs Phase 1's ~2 s ceiling. Documented in architecture.md and SKILL.md.

## Test plan

- [x] \`make validate\` locally — 394 tests pass, 0 type errors (up from 348 in Phase 1)
- [ ] CI: lint/markdown + lint/links + CodeQL green
- [ ] Manual smoke (lazy): with \`auto_spawn = true\` + model paths set, first \`/see\` spawns \`llama-server\`, second is hot, \`make vlm_server_stop\` cleans up
- [ ] Manual smoke (user-managed): with \`auto_spawn = false\`, no spawn attempted; user starts server manually
- [ ] Manual smoke (remote): with \`server_url = \"http://my-rig:8080\"\` + \`auto_spawn = true\`, no local spawn (host non-loopback)

## Non-goals

- No bundled \`llama-server\` install — user installs llama.cpp themselves.
- No version bump — consolidated in Phase 3 PR for 0.9.0 release.
- No \`fcntl\` locking — best-effort concurrency (documented).
- SessionStart preload + SessionEnd shutdown — Phase 3 (next PR).

Builds on PR #108 (Phase 1, merged in main as 88ff3f9). Re-opens the work originally tracked in closed PR #109 (squashed mega-commit; now split into four topical commits).

Generated with Claude <noreply@anthropic.com>