### PR TITLE
chore(deps-dev): bump pyright 1.1.408 → 1.1.409

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ all = [
     "cc-senses-bridge[stt]",
     "cc-senses-bridge[see]",
 ]
-dev = ["ruff>=0.15.10", "pyright>=1.1.408", "bump-my-version>=1.3.0"]
+dev = ["ruff>=0.15.10", "pyright>=1.1.409", "bump-my-version>=1.3.0"]
 test = ["pytest>=9.0.3", "pytest-cov>=6.0"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

One-line dev-dependency bump. Patch version of the type checker — no API or behavior changes expected. Resolves the recurring \"there is a new pyright version available\" warning at the top of every \`make validate\` run.

## Remote health audit (cleared)

Verified zero open issues across the three monitoring sources before opening this PR:

- **Dependabot alerts**: \`[]\` (none open)
- **CodeQL alerts**: \`[]\` (none open)
- **CodeFactor**: grade **A+**, 0 open issues across 80 analyzed files

## Test plan

- [ ] \`make validate\` locally — should still report 403+ tests pass, 0 type errors
- [ ] CI: lint/markdown + lint/links + CodeQL + CodeFactor green

## Non-goals

- No version bump for the project itself — pyright is dev-only.
- No retroactive tag here — \`v0.9.0\` tag lands separately at the previous merge SHA \`2e7c43d\` after this merges.

Generated with Claude <noreply@anthropic.com>