### PR TITLE
chore: rename cc-senses-bridge → cc-senses-plugin + v0.10.0

### DIFF
--- a/.cc-senses.example.toml
+++ b/.cc-senses.example.toml
@@ -1,4 +1,4 @@
-# cc-senses-bridge configuration
+# cc-senses-plugin configuration
 # Copy to .cc-senses.toml and adjust as needed.
 #
 # Handler-name values for [vlm] are listed in docs/architecture.md.

--- a/.cc-senses.toml
+++ b/.cc-senses.toml
@@ -1,4 +1,4 @@
-# cc-senses-bridge configuration
+# cc-senses-plugin configuration
 # Copy to .cc-senses.toml and adjust as needed.
 #
 # Handler-name values for [vlm] are listed in docs/architecture.md.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "cc-senses-bridge",
+  "name": "cc-senses-plugin",
   "owner": {
     "name": "qte77"
   },
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "cc-senses-bridge",
+      "name": "cc-senses-plugin",
       "source": "./",
       "description": "Local multimodal I/O — /speak (TTS), /listen (STT), /see (VLM)",
       "version": "0.9.0"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Local multimodal I/O bridge for Claude Code — voice and vision",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "plugins": [
     {
       "name": "cc-senses-plugin",
       "source": "./",
       "description": "Local multimodal I/O — /speak (TTS), /listen (STT), /see (VLM)",
-      "version": "0.9.0"
+      "version": "0.10.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "cc-senses-bridge",
+  "name": "cc-senses-plugin",
   "version": "0.9.0",
   "description": "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see).",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-senses-plugin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see).",
   "author": {
     "name": "qte77"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,7 @@
     "commit-helper@qte77-claude-code-utils": true,
     "codebase-tools@qte77-claude-code-utils": true,
     "cc-meta@qte77-claude-code-utils": true,
-    "cc-senses-bridge@cc-senses-bridge": true,
+    "cc-senses-plugin@cc-senses-plugin": true,
     "security-audit@qte77-claude-code-utils": true,
     "makefile-core@qte77-claude-code-utils": true,
     "docs-generator@qte77-claude-code-utils": true,
@@ -79,10 +79,10 @@
         "repo": "qte77/claude-code-plugins"
       }
     },
-    "cc-senses-bridge": {
+    "cc-senses-plugin": {
       "source": {
         "source": "github",
-        "repo": "qte77/cc-senses-bridge"
+        "repo": "qte77/cc-senses-plugin"
       }
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-13
+
+### Changed
+
+- chore: rename plugin slug `cc-senses-bridge` → `cc-senses-plugin` to align with the canonical GitHub repo name (renamed 2026-05-13). Touches `plugin.json`, `marketplace.json`, `pyproject.toml`, all source identifier strings, Makefile recipe descriptions, docs, README, and the `~/.cache/cc-senses-bridge/` → `~/.cache/cc-senses-plugin/` cache directory paths. Python module names (`cc_tts`, `cc_stt`, `cc_vlm`, `cc_voice_common`) and the config file (`.cc-senses.toml`) are intentionally preserved — the "senses" stem stays recognizable and avoids forcing users through another config-file migration.
+
+### Migration notes
+
+- Move cached VLM models: `mv ~/.cache/cc-senses-bridge ~/.cache/cc-senses-plugin` (or re-run `make setup_see` to re-download)
+- Reinstall the plugin: `make plugin_uninstall && make plugin_install_local`
+- Install command changes to `claude plugin install cc-senses-plugin@cc-senses-plugin`
+- `.cc-senses.toml` filename is unchanged; only the header comment was updated
+
 ## [0.9.0] - 2026-05-13
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 # -- VLM model + llama-cpp-python wheel URLs (single source of truth) --
 # Update these vars when bumping recommended models or wheel index URLs.
-VLM_MODELS_DIR          := $(HOME)/.cache/cc-senses-bridge/models
+VLM_MODELS_DIR          := $(HOME)/.cache/cc-senses-plugin/models
 VLM_MOONDREAM_MODEL_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-text-model-f16_ct-q4_0.gguf
 VLM_MOONDREAM_MMPROJ_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-mmproj-f16.gguf
 VLM_QWEN25_MODEL_URL    := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
@@ -31,7 +31,7 @@ LLAMA_CPP_INDEX_CUDA124 := https://abetlen.github.io/llama-cpp-python/whl/cu124
 # MARK: SETUP
 
 
-setup: ## Install cc-senses-bridge package (frozen lockfile)
+setup: ## Install cc-senses-plugin package (frozen lockfile)
 	uv sync --frozen
 
 setup_dev: ## Install with dev + test deps + all extras
@@ -120,7 +120,7 @@ setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (alt VLM, richer
 
 setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no dev tools)
 	@echo ""
-	@echo "  ✓ cc-senses-bridge ready for /speak via Kokoro."
+	@echo "  ✓ cc-senses-plugin ready for /speak via Kokoro."
 	@echo "  Try: cc-tts 'hello from claude code'"
 	@echo ""
 	@echo "  Opt-in for more:"
@@ -131,16 +131,16 @@ setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no
 
 setup_all: setup_dev setup_espeak setup_piper setup_kokoro setup_stt ## Developer happy path: dev tools + all TTS + STT
 	@echo ""
-	@echo "✓ cc-senses-bridge ready."
+	@echo "✓ cc-senses-plugin ready."
 	@echo "  Try: cc-tts 'hello from claude code'"
 	@echo "  Then in Claude Code: /speak --toggle"
 
 clean: ## Remove venv + caches (preserves downloaded TTS/STT/VLM models)
 	rm -rf .venv .pytest_cache .ruff_cache .coverage
 
-clean_models: ## Remove downloaded VLM models (~/.cache/cc-senses-bridge/models/)
-	@echo "Removing $$HOME/.cache/cc-senses-bridge/models/ ..."
-	@rm -rf $$HOME/.cache/cc-senses-bridge/models
+clean_models: ## Remove downloaded VLM models (~/.cache/cc-senses-plugin/models/)
+	@echo "Removing $$HOME/.cache/cc-senses-plugin/models/ ..."
+	@rm -rf $$HOME/.cache/cc-senses-plugin/models
 
 clean_see_artifacts: ## Remove /tmp JPEG artifacts produced by cc_vlm --save-only
 	@echo "Removing /tmp JPEG captures ..."
@@ -148,7 +148,7 @@ clean_see_artifacts: ## Remove /tmp JPEG artifacts produced by cc_vlm --save-onl
 
 clean_all: clean clean_models clean_see_artifacts ## Remove venv + caches + models + temp artifacts (full local reset)
 	@echo ""
-	@echo "  All cc-senses-bridge local artifacts removed."
+	@echo "  All cc-senses-plugin local artifacts removed."
 	@echo "  For Claude Code plugin removal also run: make plugin_uninstall"
 
 
@@ -226,8 +226,8 @@ see_save_only: ## Capture screen + save JPEG, print path (smoke-test mss + proce
 # MARK: VLM SERVER
 
 
-vlm_server_status: ## Check if cc-senses-bridge's spawned llama-server is running
-	pidfile=$$HOME/.cache/cc-senses-bridge/llama-server.pid
+vlm_server_status: ## Check if cc-senses-plugin's spawned llama-server is running
+	pidfile=$$HOME/.cache/cc-senses-plugin/llama-server.pid
 	if [ ! -f $$pidfile ]; then
 		echo "llama-server not running (no pidfile at $$pidfile)"
 		exit 0
@@ -239,11 +239,11 @@ vlm_server_status: ## Check if cc-senses-bridge's spawned llama-server is runnin
 		echo "llama-server not running (stale pidfile points at PID $$pid)"
 	fi
 
-vlm_server_stop: ## Stop cc-senses-bridge-spawned llama-server (no-op if external/unmanaged)
+vlm_server_stop: ## Stop cc-senses-plugin-spawned llama-server (no-op if external/unmanaged)
 	uv run python -c "from cc_vlm.server_manager import shutdown; shutdown(only_if_ours=True); print('  llama-server stopped (or already stopped)')"
 
-vlm_server_logs: ## Tail the spawned llama-server log (~/.cache/cc-senses-bridge/llama-server.log)
-	logfile=$$HOME/.cache/cc-senses-bridge/llama-server.log
+vlm_server_logs: ## Tail the spawned llama-server log (~/.cache/cc-senses-plugin/llama-server.log)
+	logfile=$$HOME/.cache/cc-senses-plugin/llama-server.log
 	if [ ! -f $$logfile ]; then
 		echo "No log file at $$logfile"
 		exit 1
@@ -281,18 +281,18 @@ smoke: smoke_imports smoke_cli test ## Full smoke: imports + CLIs + test suite
 plugin_validate: ## Validate the local plugin manifest without installing
 	claude plugin validate .
 
-plugin_install_local: ## Install cc-senses-bridge from the local working tree (project scope)
+plugin_install_local: ## Install cc-senses-plugin from the local working tree (project scope)
 	@echo "Registering local repo as a project-scope marketplace ..."
 	claude plugin marketplace add "$(CURDIR)" --scope project
-	@echo "Installing cc-senses-bridge from local marketplace ..."
-	claude plugin install cc-senses-bridge@cc-senses-bridge --scope project
+	@echo "Installing cc-senses-plugin from local marketplace ..."
+	claude plugin install cc-senses-plugin@cc-senses-plugin --scope project
 	@echo ""
 	@echo "  ✓ plugin installed (project scope). Verify: make plugin_list"
 	@echo "  Then: make run_cc  (try /speak /listen /see in the session)"
 
-plugin_uninstall: ## Remove cc-senses-bridge plugin + local marketplace
-	-claude plugin uninstall cc-senses-bridge
-	-claude plugin marketplace remove cc-senses-bridge --scope project
+plugin_uninstall: ## Remove cc-senses-plugin plugin + local marketplace
+	-claude plugin uninstall cc-senses-plugin
+	-claude plugin marketplace remove cc-senses-plugin --scope project
 
 plugin_list: ## Show installed Claude Code plugins
 	claude plugin list
@@ -313,8 +313,8 @@ run_voice_stream_json: ## Speak Claude response via stream-json (non-interactive
 run_repl: ## Interactive REPL with stream-json TTS (no Ink UI, sandbox-safe)
 	uv run cc-tts-repl
 
-reinstall_plugin: ## Force-reinstall cc-senses-bridge plugin (busts stale cache)
-	claude plugin install cc-senses-bridge@cc-senses-bridge --force
+reinstall_plugin: ## Force-reinstall cc-senses-plugin plugin (busts stale cache)
+	claude plugin install cc-senses-plugin@cc-senses-plugin --force
 
 
 # MARK: VERSION

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-cc-senses-bridge
+cc-senses-plugin
 Copyright 2026 qte77
 
 This product includes software developed by qte77.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Local multimodal I/O bridge for Claude Code — TTS output via `/speak`, STT input via `/listen`, screen-vision via `/see`.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.9.0-58f4c2.svg)
+![Version](https://img.shields.io/badge/version-0.10.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin/badge)](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin)
 [![Dependabot](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# cc-senses-bridge
+# cc-senses-plugin
 
 > Local multimodal I/O bridge for Claude Code — TTS output via `/speak`, STT input via `/listen`, screen-vision via `/see`.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-0.9.0-58f4c2.svg)
-[![CodeQL](https://github.com/qte77/cc-senses-bridge/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/codeql.yaml)
-[![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-senses-bridge/badge)](https://www.codefactor.io/repository/github/qte77/cc-senses-bridge)
-[![Dependabot](https://github.com/qte77/cc-senses-bridge/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/dependabot/dependabot-updates)
-[![Lint MD and Links](https://github.com/qte77/cc-senses-bridge/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/cc-senses-bridge/actions/workflows/lint-md-links.yml)
+[![CodeQL](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin/badge)](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin)
+[![Dependabot](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates)
+[![Lint MD and Links](https://github.com/qte77/cc-senses-plugin/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/lint-md-links.yml)
 
 Local multimodal I/O for Claude Code. TTS speaks Claude's responses aloud, STT captures voice input via Moonshine/Vosk, VLM ingests the screen and feeds it as text into Claude's context for Claude to act on.
 
@@ -46,7 +46,7 @@ Copy [`.cc-senses.example.toml`](.cc-senses.example.toml) to `.cc-senses.toml` a
 ## CC Plugin
 
 ```bash
-claude plugin install cc-senses-bridge@cc-senses-bridge
+claude plugin install cc-senses-plugin@cc-senses-plugin
 ```
 
 Provides `/speak`, `/listen`, `/see` skills and Stop-hook auto-read.

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -1,6 +1,6 @@
 # User Stories
 
-End-to-end flows showing how cc-senses-bridge fits into a real working session.
+End-to-end flows showing how cc-senses-plugin fits into a real working session.
 For the full configuration schema, see [`.cc-senses.example.toml`](../.cc-senses.example.toml).
 For pipeline and engine details, see [architecture.md](architecture.md).
 
@@ -26,7 +26,7 @@ Steps:
 1. `/speak --toggle` — enables Stop-hook auto-read so every response
    is spoken once it completes.
 2. `/voice` — enables Claude Code's built-in mic input.
-3. Speak a prompt → Claude transcribes → answers in text → cc-senses-bridge
+3. Speak a prompt → Claude transcribes → answers in text → cc-senses-plugin
    reads the answer aloud.
 
 Minimal config (in `.cc-senses.toml`):
@@ -55,7 +55,7 @@ Two paths exist:
   device to extract a short text summary; ~120 tokens per call. Lower
   fidelity, but cheap enough to use repeatedly.
 
-cc-senses-bridge's `/see` uses the local path by default.
+cc-senses-plugin's `/see` uses the local path by default.
 
 Steps:
 
@@ -79,8 +79,8 @@ Minimal config (run `make setup_see` to populate the paths):
 
 ```toml
 [vlm]
-model_path = "/home/USER/.cache/cc-senses-bridge/models/moondream2-text-model-f16_ct-q4_0.gguf"
-mmproj_path = "/home/USER/.cache/cc-senses-bridge/models/moondream2-mmproj-f16.gguf"
+model_path = "/home/USER/.cache/cc-senses-plugin/models/moondream2-text-model-f16_ct-q4_0.gguf"
+mmproj_path = "/home/USER/.cache/cc-senses-plugin/models/moondream2-mmproj-f16.gguf"
 handler_name = "moondream"
 ```
 
@@ -96,7 +96,7 @@ shell or REPL.
 uv run cc-tts --stop
 ```
 
-Reads the PID file at `~/.cache/cc-senses-bridge/speak.pid` and SIGTERMs the
+Reads the PID file at `~/.cache/cc-senses-plugin/speak.pid` and SIGTERMs the
 whole process group. Works for all delivery modes (Stop hook,
 stream-json, PTY proxy) — every mode writes the pidfile on start.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,13 @@
 # Architecture
 
-Single source of truth for cc-senses-bridge pipeline and engine details.
+Single source of truth for cc-senses-plugin pipeline and engine details.
 ADRs in `docs/adr/` record decisions; this file records the current design.
 
 ---
 
 ## Overview
 
-cc-senses-bridge adds three subsystems to Claude Code:
+cc-senses-plugin adds three subsystems to Claude Code:
 
 | Subsystem | Command | Role |
 |---|---|---|
@@ -101,8 +101,8 @@ Engine priority (auto-detect order): `llamacpp` → `llamaserver` (in-process pr
 
 The lifecycle helpers live in `src/cc_vlm/server_manager.py`:
 
-- PID file: `~/.cache/cc-senses-bridge/llama-server.pid`
-- Log file: `~/.cache/cc-senses-bridge/llama-server.log` (truncated on each spawn)
+- PID file: `~/.cache/cc-senses-plugin/llama-server.pid`
+- Log file: `~/.cache/cc-senses-plugin/llama-server.log` (truncated on each spawn)
 - Auto-spawn is gated on `is_localhost(server_url)` — remote hosts are assumed externally managed and silently skip the spawn attempt.
 - `ensure_running()` is idempotent: probe `/health` first, then check the pidfile, only spawn as a last resort.
 - Concurrency: best-effort, no file lock. Parallel `/see` invocations during cold start may produce transient EADDRINUSE on the loser's spawn; the system self-heals on the next invocation via `pid_is_alive`.

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -1,6 +1,6 @@
 # Engine & model landscape
 
-What we evaluated for cc-senses-bridge's three subsystems — what shipped, what's
+What we evaluated for cc-senses-plugin's three subsystems — what shipped, what's
 deferred, what's rejected and why. This is the **single source of truth
 for engine/model decisions**; `docs/architecture.md` describes the
 shipped engines in detail and `docs/roadmap/v0.5.x.md` tracks
@@ -40,7 +40,7 @@ for full details (latency, deps, notes).
 | `kokoro` (auto-detect default) | best local quality | Apache 2.0 |
 | `edge-tts` | high quality, requires internet | MIT (client); cloud service |
 | `piper` | neural VITS, ~60 MB voice models | MIT |
-| `espeak` | basic, zero-config fallback | GPL-3.0 (binary; cc-senses-bridge invokes via subprocess) |
+| `espeak` | basic, zero-config fallback | GPL-3.0 (binary; cc-senses-plugin invokes via subprocess) |
 
 ### Tracked
 
@@ -127,20 +127,20 @@ To be filed as issues; placeholder list for now.
 | Candidate | Why not |
 |---|---|
 | **inferrs** as VLM backend | Text-LLM only; no vision support anywhere in README/features. Verified via WebFetch. |
-| **DPT-2 Mini** (Landing AI) | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-senses-bridge's local-first positioning. |
+| **DPT-2 Mini** (Landing AI) | Cloud-only API, English-only, "Preview — do not use in production" status, proprietary. Every axis contradicts cc-senses-plugin's local-first positioning. |
 | **LFM2-VL-3B** (Liquid AI) | Two blockers: active CPU-only inference bug ([llama.cpp #19184](https://github.com/ggml-org/llama.cpp/issues/19184)) and LFM Open License v1.0 imposes a $10M revenue cap (not Apache 2.0). Revisit only if the bug closes AND the license relaxes. |
 | **Moondream3 (preview)** | Business Source License 1.1 — not OSI-compliant; "Additional Use Grant (No Third-Party Service)" clause forbids hosted-service use. No GGUF; transformers-only runtime. |
 | **Florence-2** (Microsoft) | Encoder-decoder architecture; not representable in GGUF / not supported by llama.cpp. Would require a parallel runtime (`transformers` or ONNX) and a different `describe()` calling convention (task-based, not chat). Out of scope for the current Protocol. |
-| **Apple FastVLM** | Apple Silicon-optimized; primary runtime is MLX, not llama.cpp. No `abetlen/llama-cpp-python` handler. Worth revisiting only if cc-senses-bridge adds an `MLXVLMEngine` backend specifically for macOS users. |
+| **Apple FastVLM** | Apple Silicon-optimized; primary runtime is MLX, not llama.cpp. No `abetlen/llama-cpp-python` handler. Worth revisiting only if cc-senses-plugin adds an `MLXVLMEngine` backend specifically for macOS users. |
 | **Phi-4-Multimodal** (Microsoft) | ~14B params; ~9-10 GB at Q4; 12 GB GPU recommended. Too heavy for CPU-only deployment. |
 
 ## Cross-subsystem frameworks
 
 ### Rejected
 
-These offered to *replace* cc-senses-bridge's architecture rather than slot into a single subsystem.
+These offered to *replace* cc-senses-plugin's architecture rather than slot into a single subsystem.
 
 | Candidate | Why not |
 |---|---|
-| **PersonaPlex** | Scope mismatch — replaces Claude Code's LLM entirely. cc-senses-bridge's value prop is "Claude Code does the thinking". Only useful as a future-direction note for the half-duplex → full-duplex frontier (see roadmap "Deferred ideas"). |
-| **TEN-framework** (Agora) | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-senses-bridge hard constraint violated. |
+| **PersonaPlex** | Scope mismatch — replaces Claude Code's LLM entirely. cc-senses-plugin's value prop is "Claude Code does the thinking". Only useful as a future-direction note for the half-duplex → full-duplex frontier (see roadmap "Deferred ideas"). |
+| **TEN-framework** (Agora) | Non-OSI clauses on top of Apache 2.0 forbid hosting on end-user devices; daemon-required runtime; bundled STT/TTS are cloud APIs (Deepgram/ElevenLabs). Full-duplex agent framework, not a half-duplex engine — every cc-senses-plugin hard constraint violated. |

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -1,4 +1,4 @@
-# cc-senses-bridge roadmap (v0.5.x → v0.6.x)
+# cc-senses-plugin roadmap (v0.5.x → v0.6.x)
 
 Living document for tracked and deferred work on the 0.5.x and 0.6.x
 development lines. **Actionable items are filed as GitHub issues** with the
@@ -7,11 +7,11 @@ development lines. **Actionable items are filed as GitHub issues** with the
 
 ## Source of truth
 
-- **Actionable work**: [GitHub issues](https://github.com/qte77/cc-senses-bridge/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
-- **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-senses-bridge/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- **Actionable work**: [GitHub issues](https://github.com/qte77/cc-senses-plugin/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+- **Bugs**: [GitHub issues `bug` label](https://github.com/qte77/cc-senses-plugin/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 - **Engine / model / framework evaluations** (shipped, deferred, rejected): [`docs/landscape.md`](../landscape.md)
 - **Deferred tooling/process ideas + rejected non-engine paths**: this file
-- **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-senses-bridge/memory/`
+- **Operational memory** (cross-session): `~/.claude/projects/-home-kingkong-repos-cc-senses-plugin/memory/`
 
 ## Recently shipped
 
@@ -65,7 +65,7 @@ the per-subsystem "Considered / deferred" tables.
   in **#60** (doc hierarchy restructure); `docs/architecture.md` and
   `CONTRIBUTING.md` already shipped in v0.6.0.
 - **ADR-0002 "full-duplex voice" future direction** — PersonaPlex / Moshi
-  architecture note. Historical record; cc-senses-bridge stays half-duplex with
+  architecture note. Historical record; cc-senses-plugin stays half-duplex with
   pluggable engines by design. Write when someone asks about the
   architectural frontier.
 - **6-line terseness prompt** in `.claude/rules/core-principles.md` — per
@@ -84,8 +84,8 @@ subsystem's "Rejected" section.
 |---|---|
 | **TurboQuant-GPU** (DevTechJr) | KV cache compression for text LLMs; NVIDIA-only; no VLM/audio support. Scope mismatch. |
 | **caveman as plugin** | Real savings are 13-21% per independent benchmark (not the viral 65-75% claim). Redundant with `core-principles.md` + `rtk` already in place. A 6-line prompt matches the full plugin's effect. |
-| **Claude Code router as cc-senses-bridge dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-senses-bridge's audio/vision pipeline is unaffected by backend routing. |
-| **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-senses-bridge doesn't need to re-document external tools. |
+| **Claude Code router as cc-senses-plugin dep** | Violates the LLM-agnostic principle. Users install their own router if they want one; cc-senses-plugin's audio/vision pipeline is unaffected by backend routing. |
+| **`docs/recipes/run-fully-local.md`** | YAGNI — upstream docs (Ollama, claude-code-router, LiteLLM) cover the how-to. cc-senses-plugin doesn't need to re-document external tools. |
 | **`context-mode`** deep research | Unresearched, not urgent. Revisit only if `rtk`'s command-output compression proves insufficient. |
 
 ## Process notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "cc-senses-bridge"
+name = "cc-senses-plugin"
 version = "0.9.0"
 description = "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see)"
 requires-python = ">=3.11"
@@ -17,10 +17,10 @@ see = ["mss>=9.0.0", "Pillow>=10.0.0", "blake3>=0.4.0", "httpx>=0.27"]
 # ROCm), typically via abetlen's prebuilt wheel indexes. See
 # `make setup_see` output and skills/see/SKILL.md for install guidance.
 all = [
-    "cc-senses-bridge[piper]",
-    "cc-senses-bridge[edge]",
-    "cc-senses-bridge[stt]",
-    "cc-senses-bridge[see]",
+    "cc-senses-plugin[piper]",
+    "cc-senses-plugin[edge]",
+    "cc-senses-plugin[stt]",
+    "cc-senses-plugin[see]",
 ]
 dev = ["ruff>=0.15.10", "pyright>=1.1.409", "bump-my-version>=1.3.0"]
 test = ["pytest>=9.0.3", "pytest-cov>=6.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-senses-plugin"
-version = "0.9.0"
+version = "0.10.0"
 description = "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see)"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -96,7 +96,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "0.9.0"
+current_version = "0.10.0"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -19,7 +19,7 @@ make setup_see           # default: Moondream2 (~0.9 GB Q4, fastest CPU)
 make setup_see_qwen25    # alt: Qwen2.5-VL-3B (~1.6 GB Q4, richer output)
 ```
 
-Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-bridge/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) for the full `[vlm]` schema.
+Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-plugin/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) for the full `[vlm]` schema.
 
 ## Engines
 
@@ -38,7 +38,7 @@ Prerequisite: `llama-server` must be installed and on your `PATH` (install via y
 
 #### 1. Lazy auto-spawn (default)
 
-cc-senses-bridge spawns `llama-server` on first `/see`, then re-uses the warm process for subsequent calls. Set in `.cc-senses.toml`:
+cc-senses-plugin spawns `llama-server` on first `/see`, then re-uses the warm process for subsequent calls. Set in `.cc-senses.toml`:
 
 ```toml
 [vlm]
@@ -59,7 +59,7 @@ make vlm_server_stop     # SIGTERM the spawned process
 
 #### 2. User-managed
 
-You start `llama-server` yourself; cc-senses-bridge just POSTs to it. Useful for shared servers, GPU rigs, or remote hosts.
+You start `llama-server` yourself; cc-senses-plugin just POSTs to it. Useful for shared servers, GPU rigs, or remote hosts.
 
 ```bash
 llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
@@ -69,7 +69,7 @@ llama-server -m /path/to/model.gguf --mmproj /path/to/mmproj.gguf --port 8080
 [vlm]
 engine = "llamaserver"
 server_url = "http://localhost:8080"
-auto_spawn = false   # cc-senses-bridge will NOT try to spawn
+auto_spawn = false   # cc-senses-plugin will NOT try to spawn
 ```
 
 For remote hosts (`server_url = "http://my-rig.local:8080"`), `auto_spawn` is implicitly disabled — only localhost / 127.0.0.1 / ::1 are eligible for auto-spawn.
@@ -131,7 +131,7 @@ make smoke                           # imports + --help + full test suite
 
 ```bash
 make plugin_validate                 # sanity-check the manifest first
-make plugin_install_local            # registers local marketplace + installs cc-senses-bridge (project scope)
+make plugin_install_local            # registers local marketplace + installs cc-senses-plugin (project scope)
 make run_cc                          # starts claude; then type /see in the session
 make plugin_uninstall                # removes plugin + marketplace when done
 ```
@@ -160,7 +160,7 @@ For an end-to-end user flow (feeding screen content to Claude so it can debug or
 |---|---|
 | Per-session cache (in-memory `DescribeCache`) | Exits with the Python process. Nothing to clean. |
 | Temp JPEGs (`/tmp/tmp*.jpg`) | `make clean_see_artifacts` |
-| Downloaded GGUF + mmproj (`~/.cache/cc-senses-bridge/models/`) | `make clean_models` |
+| Downloaded GGUF + mmproj (`~/.cache/cc-senses-plugin/models/`) | `make clean_models` |
 | Python venv + pytest/ruff caches | `make clean` |
 | All of the above at once | `make clean_all` |
 | Plugin installation (if done via `make plugin_install_local`) | `make plugin_uninstall` |

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
 """cc-stt: Speech-to-text module for cc-senses-plugin plugin."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
-"""cc-stt: Speech-to-text module for cc-senses-bridge plugin."""
+"""cc-stt: Speech-to-text module for cc-senses-plugin plugin."""
 
 __version__ = "0.9.0"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
-"""cc-senses-bridge: Local multimodal I/O bridge for Claude Code (TTS module)."""
+"""cc-senses-plugin: Local multimodal I/O bridge for Claude Code (TTS module)."""
 
 __version__ = "0.9.0"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
 """cc-senses-plugin: Local multimodal I/O bridge for Claude Code (TTS module)."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/cc_tts/hook_handler.py
+++ b/src/cc_tts/hook_handler.py
@@ -1,7 +1,7 @@
 """Stop hook handler for auto-read mode.
 
 This hook fires on EVERY Claude response (registered as a Stop hook in
-hooks/hooks.json via the cc-senses-bridge plugin). It is intentionally always-registered rather than
+hooks/hooks.json via the cc-senses-plugin plugin). It is intentionally always-registered rather than
 dynamically added/removed because CC hooks don't hot-reload — they require
 a session restart to take effect.
 
@@ -31,9 +31,9 @@ from pathlib import Path
 
 from cc_tts.config import load_config
 
-# Debug log path: ~/.cache/cc-senses-bridge/hook.log
+# Debug log path: ~/.cache/cc-senses-plugin/hook.log
 # Set CC_TTS_HOOK_DEBUG=1 to enable; disabled by default.
-_LOG_PATH = Path.home() / ".cache" / "cc-senses-bridge" / "hook.log"
+_LOG_PATH = Path.home() / ".cache" / "cc-senses-plugin" / "hook.log"
 
 
 def extract_assistant_text(stdin_data: str) -> str:
@@ -65,7 +65,7 @@ def main() -> None:
     child synthesizes and plays in background.
 
     Graceful no-op when deps are missing (team members without TTS setup).
-    Set CC_TTS_HOOK_DEBUG=1 to log diagnostics to ~/.cache/cc-senses-bridge/hook.log.
+    Set CC_TTS_HOOK_DEBUG=1 to log diagnostics to ~/.cache/cc-senses-plugin/hook.log.
     """
     _debug("hook fired")
 

--- a/src/cc_tts/repl.py
+++ b/src/cc_tts/repl.py
@@ -178,7 +178,7 @@ def main() -> None:
         args=(proc.stdout, _make_on_text(response_text, first_delta, sentence_buf), turn_done),
         daemon=True,
     ).start()
-    print("cc-senses-bridge REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read\n")
+    print("cc-senses-plugin REPL • /exit to quit, /stop to interrupt TTS, /toggle for auto-read\n")
 
     last_interrupt = 0.0
 

--- a/src/cc_tts/speak.py
+++ b/src/cc_tts/speak.py
@@ -17,7 +17,7 @@ from cc_tts.preprocess import preprocess
 _output_counter = 0
 
 # PID file for --stop interrupt. Stores the current speak PGID (process group).
-_PID_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "speak.pid"
+_PID_FILE = Path.home() / ".cache" / "cc-senses-plugin" / "speak.pid"
 
 
 def _write_pidfile() -> None:
@@ -116,7 +116,7 @@ def _toggle_auto_read() -> None:
 
 
 def main() -> None:
-    """CLI entry point for cc-senses-bridge speak.
+    """CLI entry point for cc-senses-plugin speak.
 
     Usage:
         python -m cc_tts.speak <text>       speak the given text

--- a/src/cc_tts/tts_worker.py
+++ b/src/cc_tts/tts_worker.py
@@ -47,4 +47,4 @@ def _speak_batch(speak: Callable[[str], None], batch: list[str]) -> None:
     try:
         speak(text)
     except Exception as exc:
-        print(f"[cc-senses-bridge] TTS error: {exc}", file=sys.stderr)
+        print(f"[cc-senses-plugin] TTS error: {exc}", file=sys.stderr)

--- a/src/cc_vlm/preload_hook.py
+++ b/src/cc_vlm/preload_hook.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from cc_vlm.config import load_vlm_config
 
-_LOG_PATH = Path.home() / ".cache" / "cc-senses-bridge" / "preload.log"
+_LOG_PATH = Path.home() / ".cache" / "cc-senses-plugin" / "preload.log"
 
 
 def _debug(msg: str) -> None:

--- a/src/cc_vlm/server_manager.py
+++ b/src/cc_vlm/server_manager.py
@@ -20,8 +20,8 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 
-PID_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "llama-server.pid"
-LOG_FILE = Path.home() / ".cache" / "cc-senses-bridge" / "llama-server.log"
+PID_FILE = Path.home() / ".cache" / "cc-senses-plugin" / "llama-server.pid"
+LOG_FILE = Path.home() / ".cache" / "cc-senses-plugin" / "llama-server.log"
 
 _LOCALHOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 

--- a/src/cc_vlm/shutdown_hook.py
+++ b/src/cc_vlm/shutdown_hook.py
@@ -1,4 +1,4 @@
-"""SessionEnd hook: stop the cc-senses-bridge-spawned llama-server.
+"""SessionEnd hook: stop the cc-senses-plugin-spawned llama-server.
 
 Registered as a Claude Code SessionEnd hook in hooks/hooks.json. Fires
 once when the CC session ends. Calls `server_manager.shutdown` with
@@ -15,7 +15,7 @@ import datetime
 import os
 from pathlib import Path
 
-_LOG_PATH = Path.home() / ".cache" / "cc-senses-bridge" / "shutdown.log"
+_LOG_PATH = Path.home() / ".cache" / "cc-senses-plugin" / "shutdown.log"
 
 
 def _debug(msg: str) -> None:

--- a/src/cc_voice_common/__init__.py
+++ b/src/cc_voice_common/__init__.py
@@ -1,1 +1,1 @@
-"""Shared utilities for cc-senses-bridge plugins."""
+"""Shared utilities for cc-senses-plugin plugins."""

--- a/src/cc_voice_common/config.py
+++ b/src/cc_voice_common/config.py
@@ -1,4 +1,4 @@
-"""Shared config utilities — TOML discovery and section loading for cc-senses-bridge plugins."""
+"""Shared config utilities — TOML discovery and section loading for cc-senses-plugin plugins."""
 
 from __future__ import annotations
 

--- a/uv.lock
+++ b/uv.lock
@@ -270,7 +270,7 @@ wheels = [
 ]
 
 [[package]]
-name = "cc-senses-bridge"
+name = "cc-senses-plugin"
 version = "0.9.0"
 source = { editable = "." }
 dependencies = [
@@ -316,10 +316,10 @@ test = [
 requires-dist = [
     { name = "blake3", marker = "extra == 'see'", specifier = ">=0.4.0" },
     { name = "bump-my-version", marker = "extra == 'dev'", specifier = ">=1.3.0" },
-    { name = "cc-senses-bridge", extras = ["edge"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras = ["piper"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras = ["see"], marker = "extra == 'all'" },
-    { name = "cc-senses-bridge", extras = ["stt"], marker = "extra == 'all'" },
+    { name = "cc-senses-plugin", extras = ["edge"], marker = "extra == 'all'" },
+    { name = "cc-senses-plugin", extras = ["piper"], marker = "extra == 'all'" },
+    { name = "cc-senses-plugin", extras = ["see"], marker = "extra == 'all'" },
+    { name = "cc-senses-plugin", extras = ["stt"], marker = "extra == 'all'" },
     { name = "edge-tts", marker = "extra == 'edge'", specifier = ">=7.2.8" },
     { name = "httpx", marker = "extra == 'see'", specifier = ">=0.27" },
     { name = "mss", marker = "extra == 'see'", specifier = ">=9.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "cc-senses-plugin"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Summary

Aligns in-tree strings with the canonical GitHub repo name (renamed 2026-05-13 from \`cc-senses-bridge\` to \`cc-senses-plugin\`). Mirrors PR #107's pattern for the prior \`cc-voice\` → \`cc-senses-bridge\` migration.

## Decisions locked in (per AskUserQuestion)

- **Config file**: \`.cc-senses.toml\` unchanged — the \"senses\" stem stays recognizable and avoids forcing users through a third config-file migration.
- **Cache directory**: renamed (\`~/.cache/cc-senses-bridge/\` → \`~/.cache/cc-senses-plugin/\`) to match canonical. Users \`mv\` or re-run \`make setup_see\`.
- **Version bump**: 0.9.0 → 0.10.0 minor (same precedent as PR #107's 0.7→0.8 rename — signals user-impacting cache migration).

## Commits (topical)

1. **\`chore(plugin): rename plugin slug\`** — \`plugin.json\` / \`marketplace.json\` / \`pyproject.toml\` name + extras self-refs / \`uv.lock\` project entry
2. **\`chore(rename): cc-senses-bridge → cc-senses-plugin in src/ + Makefile\`** — cache paths + source identifier strings + Makefile recipes (install commands, descriptions, VLM_MODELS_DIR)
3. **\`chore(rename): update config/settings/NOTICE references\`** — \`.claude/settings.json\` enabled-plugin + marketplace, \`NOTICE\`, header comments in \`.cc-senses.toml\` / \`.cc-senses.example.toml\`
4. **\`docs(rename): update README + docs + skills for cc-senses-plugin\`** — current-state documentation only; CHANGELOG historical entries deliberately preserved
5. **\`chore(release): bump version 0.9.0 → 0.10.0\`** — version-bearing files + CHANGELOG \`[0.10.0]\` entry with migration notes

## Remote health audit (pre-PR)

Verified clean before opening:

- Dependabot alerts: \`[]\`
- CodeQL alerts: \`[]\`
- CodeFactor: grade **A+**, 0 open issues

## Test plan

- [ ] \`make validate\` locally — expect ~403 tests pass (no test changes)
- [ ] CI: lint/markdown + lint/links + CodeQL + CodeFactor green
- [ ] Manual smoke: \`make plugin_install_local\` resolves to \`cc-senses-plugin@cc-senses-plugin\`
- [ ] Manual smoke: \`make vlm_server_status\` reads from \`~/.cache/cc-senses-plugin/\` (after migration)

## Non-goals

- No code-behavior changes — pure name alignment.
- No \`.cc-senses.toml\` filename change (kept for user friction reasons).
- No Python module rename (\`cc_tts\`, \`cc_stt\`, \`cc_vlm\`, \`cc_voice_common\` stay).

## Post-merge

Retroactive tag \`v0.10.0\` at the squash-merge SHA.

Generated with Claude <noreply@anthropic.com>