### PR TITLE
chore(lockfile): sync pyright 1.1.409 wheel URLs + hashes

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'see'", specifier = ">=10.0.0" },
     { name = "piper-tts", marker = "extra == 'piper'", specifier = ">=1.2.0" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.409" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
@@ -1406,15 +1406,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Companion to #112 — completes the lockfile sync that should have been part of the original pyright bump. 4-line diff in \`uv.lock\` updating the pyright wheel URLs, sdist URLs, and hashes from 1.1.408 → 1.1.409 to match the \`>=1.1.409\` constraint that landed in pyproject.toml.

## Background

PR #112 bumped \`pyright>=1.1.408\` → \`>=1.1.409\` in \`pyproject.toml\`'s \`[project.optional-dependencies] dev\` group, but did not run \`uv lock\` afterward. The result: the lockfile's project-version entry got bumped (because \`uv\` sees the modified pyproject and re-syncs the project's own entry on next \`uv run\`), but the actual pyright wheel/sdist URLs + hashes stayed on the 1.1.408 entries. \`make validate\`'s implicit \`uv sync\` caught it later.

## Test plan

- [ ] \`make validate\` locally — should still pass cleanly
- [ ] CI: lint/markdown + lint/links + CodeQL + CodeFactor green

Pure metadata sync, no code or behavior change.

Generated with Claude <noreply@anthropic.com>