### PR TITLE
docs: refresh roadmap + UserStory + architecture + ADR-0003 for v0.7→v0.10

### DIFF
--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -84,8 +84,34 @@ mmproj_path = "/home/USER/.cache/cc-senses-plugin/models/moondream2-mmproj-f16.g
 handler_name = "moondream"
 ```
 
+### Hot-model variant (shipped in v0.9.0)
+
+The default `llamacpp` engine reloads the model on every `/see`
+invocation (each call is a fresh Python process — the in-process
+warm-cache benefit doesn't apply to the CLI workflow). For
+genuinely-warm latency across calls, switch to the `llamaserver`
+backend, which keeps the model resident in a long-lived
+`llama-server` daemon:
+
+```toml
+[vlm]
+engine = "llamaserver"
+model_path = "/path/to/model.gguf"
+mmproj_path = "/path/to/mmproj.gguf"
+auto_spawn = true   # default; first /see spawns llama-server in the background
+# preload = true    # opt-in: spawn at session start so even the first /see is warm
+```
+
+Three lifecycle modes — see
+[`docs/architecture.md` § Server lifecycle](architecture.md#server-lifecycle).
+The `llamaserver` engine also unlocks model families that the
+in-process backend can't reach (SmolVLM2, Qwen3-VL — anything
+`llama.cpp` supports but `abetlen/llama-cpp-python` hasn't shipped a
+chat-handler for yet).
+
 See [`docs/adr/0003-vlm-screen-sharing.md`](adr/0003-vlm-screen-sharing.md)
-for the rationale behind the in-process VLM choice.
+for the rationale behind the local-VLM choice (originally
+in-process-only; v0.9.0 added the HTTP-server alternative).
 
 ## Flow C: Hotkey-stopped playback
 

--- a/docs/adr/0003-vlm-screen-sharing.md
+++ b/docs/adr/0003-vlm-screen-sharing.md
@@ -30,3 +30,30 @@ complex, defer until Tier 2 proves insufficient.
 - Cold-start ~3-5 s (model load), warm calls ~200-500 ms
 - Large model files (1-4 GB) affect first-run experience
 - BLAKE3 frame cache eliminates redundant VLM calls
+
+---
+
+## Update (2026-05-13) — what shipped beyond the original decision
+
+The original ADR proposed a single in-process `llama-cpp-python` MVP
+with Qwen2.5-VL-3B. Three subsequent changes are worth recording:
+
+- **Default flipped Qwen2.5-VL-3B → Moondream2** (v0.7.0, #91).
+  Moondream2 Q4 is ~0.9 GB vs Qwen2.5-VL-3B's ~1.6 GB and faster on
+  CPU. Qwen2.5-VL stays available via `make setup_see_qwen25`.
+- **`LlamaServerVLMEngine` HTTP backend shipped** (v0.9.0, #108).
+  Same `llama.cpp` binary as the in-process path, but as a long-lived
+  daemon — routes around the `abetlen/llama-cpp-python` chat-handler
+  gap (unlocks SmolVLM2 + Qwen3-VL today) AND fixes the false-warm
+  problem: `/see` invokes a fresh Python process per call, so the
+  in-process engine never actually runs hot across CLI invocations.
+- **Three lifecycle modes** (v0.9.0, #110 + #111): user-managed,
+  lazy auto-spawn (default), and SessionStart preload. `cc_vlm.server_manager`
+  owns spawn / pidfile / health-probe / shutdown.
+
+**Tier 1 (Claude Vision API)** remains deferred — no demand surfaced.
+**Tier 3 (hybrid)** also deferred — Tier 2 has proven sufficient with
+the lifecycle additions.
+
+See [`docs/architecture.md` § VLM Pipeline](../architecture.md#vlm-pipeline)
+for the current state of all of this.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ Engine priority (auto-detect order): `llamacpp` → `llamaserver` (in-process pr
 | Engine | Backend | Daemon | RAM idle | Latency (warm) | Notes |
 |---|---|---|---|---|---|
 | **llamacpp** (default) | llama-cpp-python | None | 0 (but cold-starts every `/see` — fresh Python process) | ~200-500 ms (within one process; rare for CLI) | In-process; no HTTP. Cold-starts on every `/see` invocation. |
-| **llamaserver** | `llama-server` HTTP | Yes (user-managed in Phase 1; lazy auto-spawn in Phase 2; preloaded in Phase 3) | ~1-2 GB while alive | ~200-500 ms (genuinely warm across `/see` calls) | Same llama.cpp binary as in-process; unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs |
+| **llamaserver** | `llama-server` HTTP | Yes (user-managed / lazy auto-spawn / preloaded — see Server lifecycle below) | ~1-2 GB while alive | ~200-500 ms (genuinely warm across `/see` calls) | Same llama.cpp binary as in-process; unlocks SmolVLM2, Qwen3-VL, and any GGUF llama.cpp supports without waiting for `abetlen/llama-cpp-python` handler PRs |
 | ClaudeVisionEngine (deferred) | Claude Vision API | None | 0 | ~1-3 s | ~1,600 tokens/call; opt-in `--vision` |
 
 **Why `llama-server` and not Ollama**: same llama.cpp binary already used by the in-process path, no extra daemon family to support, no Ollama-as-dependency. Ollama was considered and rejected on those grounds during the #91 research pass.

--- a/docs/roadmap/v0.5.x.md
+++ b/docs/roadmap/v0.5.x.md
@@ -1,9 +1,12 @@
-# cc-senses-plugin roadmap (v0.5.x → v0.6.x)
+# cc-senses-plugin roadmap
 
-Living document for tracked and deferred work on the 0.5.x and 0.6.x
-development lines. **Actionable items are filed as GitHub issues** with the
+Living document tracking shipped releases, deferred work, and rejected
+directions. **Actionable items are filed as GitHub issues** with the
 `enhancement` label; this file captures the **deferred** items and
 **rejected** directions that don't belong in the issue tracker.
+
+(File still named `v0.5.x.md` for git-history continuity; content covers
+the whole release line.)
 
 ## Source of truth
 
@@ -20,6 +23,10 @@ development lines. **Actionable items are filed as GitHub issues** with the
 | **v0.4.0** (tagged 2026-04-11) | #14, #17, #18, #19, #20, #21, #22, #23, #24, #25 | `/listen` pipeline, ADR-0003 (VLM screen-sharing), build + typing cleanup, dep-bump sweep, repo hygiene |
 | **v0.5.0** (tagged 2026-04-11) | #26, #28, #36 | `/see` module (`cc_vlm` with `llama-cpp-python`), `setup_user` Makefile target |
 | **v0.6.0** (tagged 2026-04-23) | #29, #33, #39, #56, #70, #71, #72, #73 | listen token optimization, streaming sentence TTS in REPL, pydantic config migration, ADR-0001 refresh, CONTRIBUTING.md, bump-helper scripts |
+| **v0.7.0** (tagged 2026-05-08) | #91, #105 | VLM default flipped from Qwen2.5-VL-3B → Moondream2; guided `make setup_see` / `setup_see_qwen25` targets; `docs/landscape.md` engine-evaluation matrix |
+| **v0.8.0** (tagged 2026-05-12) | #107 | Project rename `cc-voice` → `cc-senses-bridge` to reflect multimodal scope (TTS + STT + VLM). Config file + cache dir migrated |
+| **v0.9.0** (tagged 2026-05-13) | #108, #110, #111 | VLM lifecycle: `LlamaServerVLMEngine` HTTP backend; `server_manager` with lazy auto-spawn; SessionStart preload + SessionEnd shutdown hooks. Closes #101 |
+| **v0.10.0** (tagged 2026-05-13) | #112, #113, #114 | Rename `cc-senses-bridge` → `cc-senses-plugin` (canonical repo name); pyright 1.1.408 → 1.1.409; lockfile sync |
 
 ## Tracked in GitHub issues (actionable)
 
@@ -28,10 +35,16 @@ Filed alongside this roadmap — see each issue for full scope + acceptance crit
 - **#30** — `feat(tts): Kokoro voice blending via embedding math`
 - **#31** — `feat(stt): Whisper engine via faster-whisper (enables domain fine-tunes)`
 - **#32** — `feat(stt): Parakeet-TDT-0.6B-v3 engine via onnx-asr (multilingual, CC-BY-4.0)`
-- **#45** — `bug(plugin): stale plugin cache not refreshed from local directory source`
-- **#60** — `docs: restructure doc hierarchy — slim ADRs, add architecture.md, UserStory.md`
+- **#103** — `feat(vlm): harden available() against handler-class-mismatch` — small companion to the in-process VLM path; verifies `llama_cpp.llama_chat_format` actually exports the requested handler class before claiming the engine is available
+- **#106** — `bug: Plugin hook and /speak skill fail in consuming projects`
 
-When one of these lands, link back to this file if scope expanded or contracted.
+Upstream-blocked, kept as trackers only:
+
+- **#102** — `feat(vlm): add Qwen3VLChatHandler once abetlen/llama-cpp-python ships #2080` — `LlamaServerVLMEngine` is the unblock path until upstream lands the handler
+
+Meta:
+
+- **#85** — `discuss: roadmap-drift prevention — pick A / B / C` — addresses why this file repeatedly goes stale
 
 ## Deferred ideas — not currently filed as issues
 


### PR DESCRIPTION
## Summary

Catches the four main docs up to where the code actually is. None of these touch behavior — pure historical/state cleanup. Closes the immediate concern raised in #85 (roadmap drift) for the v0.7→v0.10 window.

## Commits (topical)

1. **\`docs(roadmap): refresh shipped table + prune closed issue trackers\`**
   - Title drops the "(v0.5.x → v0.6.x)" qualifier — we've shipped through v0.10.0
   - \"Recently shipped\" table extended with v0.7→v0.10 rows
   - Tracked-issues list: removed #45 + #60 (closed); added #103 + #106; new \"upstream-blocked\" bucket for #102; meta-bucket for #85
2. **\`docs(userstory): document llama-server hot-model variant for Flow B\`**
   - Flow B previously only covered the in-process llamacpp engine — added a \"Hot-model variant\" subsection with the v0.9.0 llamaserver config, lazy/preload modes, and the SmolVLM2/Qwen3-VL unblock context
3. **\`docs(architecture): drop redundant Phase 1/2/3 labels in VLM engine table\`**
   - The lifecycle phases were useful while stacked across PRs #108/#110/#111; now they're noise. Replaced with \"user-managed / lazy auto-spawn / preloaded\" + pointer to the Server lifecycle subsection
4. **\`docs(adr): note v0.7-v0.9 VLM evolution beyond ADR-0003 baseline\`**
   - Appends an \"Update (2026-05-13)\" section to ADR-0003 noting: default flip Qwen2.5-VL-3B → Moondream2 (v0.7.0), LlamaServerVLMEngine HTTP backend (v0.9.0), three lifecycle modes (v0.9.0). Preserves the original decision record verbatim.

## ADR scope check

- **ADR-0001 (TTS delivery modes)** — still accurate; no edits
- **ADR-0002 (STT engine selection)** — still accurate; no edits
- **ADR-0003 (VLM screen-sharing)** — gets the \"Update\" section above

## Test plan

- [ ] CI: lint/markdown + lint/links pass (no code changes, but lint-md and lychee should be happy with the new structure)
- [ ] No \`make validate\` impact — pure docs

## Non-goals

- No code changes
- No version bump (docs-only)
- No new ADRs — the v0.9.0 lifecycle work didn't introduce a new architectural decision separate from ADR-0003; an Update section is the right shape

Generated with Claude <noreply@anthropic.com>