### PR TITLE
test: prune 7 trivial / non-value-adding tests (stacked on #116)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Local multimodal I/O bridge for Claude Code — voice and vision",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "plugins": [
     {
       "name": "cc-senses-plugin",
       "source": "./",
       "description": "Local multimodal I/O — /speak (TTS), /listen (STT), /see (VLM)",
-      "version": "0.10.0"
+      "version": "0.10.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-senses-plugin",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see).",
   "author": {
     "name": "qte77"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-15
+
+### Fixed
+
+- All four `setup_see` / `setup_see_qwen25` URLs were dead: `ggml-org/moondream2-20250414-GGUF` never shipped the `f16_ct-q4_0.gguf` filename the Makefile asked for (only `f16_ct-vicuna` and `mmproj-f16-20250414`), and `bartowski/Qwen2.5-VL-3B-Instruct-GGUF` was removed entirely. Repointed at canonical author repos: `moondream/moondream2-gguf` (F16 only — no Q4 published at canonical source) and `lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF` (Q4_K_M).
+
+### Changed
+
+- VLM model registry pivoted to `src/cc_vlm/models.toml` + `python -m cc_vlm.setup_models <key>`. URL constants and filename literals no longer live in the Makefile — filenames are derived from URL basenames by construction, so the drift class of bug that caused the v0.10.0 dead URLs is structurally impossible going forward. Make recipes collapsed from 66 lines of shell to 12 lines of one-liners.
+
+### Added
+
+- `make setup_see_qwen3vl` — llamaserver opt-in target for Qwen3-VL-2B (official Qwen, apache-2.0, ~1.55 GB Q4_K_M text + Q8 mmproj). Reachable through `LlamaServerVLMEngine` without waiting on `abetlen/llama-cpp-python` to ship a `Qwen3VLChatHandler`.
+- `make setup_see_smolvlm` — llamaserver opt-in target for SmolVLM-500M (ggml-org, apache-2.0, 546 MB total). The "fits-on-anything" tier for low-spec laptops.
+- `make setup_default_all` — kitchen-sink: dev tools + all TTS engines + STT + the in-process default `/see` tier (Moondream2).
+- `src/cc_vlm/setup_models.py` — TOML-driven loader, downloader, and engine-aware `[vlm]` snippet emitter with platform-aware llama-cpp-python / llama-server install hints.
+
+### Migration notes
+
+- Re-run `make setup_see` (or `make clean_models && make setup_see`) to fetch the new, working Moondream2 GGUFs. Model files have new basenames: `moondream2-text-model-f16.gguf` (was `f16_ct-q4_0.gguf`) and `moondream2-mmproj-f16.gguf` (unchanged).
+- Existing `.cc-senses.toml` files keep working — config schema is unchanged. Only the `model_path` / `mmproj_path` values need to point at the new filenames if you reuse the installer's printed snippet.
+
 ## [0.10.0] - 2026-05-13
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 .ONESHELL:
 .PHONY: \
 	setup setup_dev setup_espeak setup_piper setup_kokoro setup_stt \
-	setup_see setup_see_qwen25 setup_user setup_all \
+	setup_see setup_see_qwen25 setup_see_qwen3vl setup_see_smolvlm \
+	setup_user setup_all setup_default_all \
 	clean validate lint_fix quick_validate lint_src lint_tests lint_md lint_links \
 	type_check test test_coverage speak wrap \
 	vlm_server_status vlm_server_stop vlm_server_logs \
@@ -17,15 +18,9 @@ ifndef VERBOSE
   COV_QUIET    := --cov-report=
 endif
 
-# -- VLM model + llama-cpp-python wheel URLs (single source of truth) --
-# Update these vars when bumping recommended models or wheel index URLs.
-VLM_MODELS_DIR          := $(HOME)/.cache/cc-senses-plugin/models
-VLM_MOONDREAM_MODEL_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-text-model-f16_ct-q4_0.gguf
-VLM_MOONDREAM_MMPROJ_URL := https://huggingface.co/ggml-org/moondream2-20250414-GGUF/resolve/main/moondream2-mmproj-f16.gguf
-VLM_QWEN25_MODEL_URL    := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
-VLM_QWEN25_MMPROJ_URL   := https://huggingface.co/bartowski/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
-LLAMA_CPP_INDEX_CPU     := https://abetlen.github.io/llama-cpp-python/whl/cpu
-LLAMA_CPP_INDEX_CUDA124 := https://abetlen.github.io/llama-cpp-python/whl/cu124
+# VLM model URLs + filenames live in src/cc_vlm/models.toml — never inlined here.
+# `cc_vlm.setup_models` is the single source of truth for downloads + snippets.
+VLM_MODELS_DIR := $(HOME)/.cache/cc-senses-plugin/models
 
 
 # MARK: SETUP
@@ -59,64 +54,21 @@ setup_kokoro: ## Install Kokoro TTS (best local quality, ~82MB model)
 setup_stt: ## Install STT deps (sounddevice + default engine)
 	uv sync --extra stt
 
-setup_see: ## Install /see deps + download Moondream2 (recommended default VLM)
+setup_see: ## Install /see deps + download Moondream2 (default in-process VLM)
 	uv sync --extra see
-	mkdir -p $(VLM_MODELS_DIR)
-	model=$(VLM_MODELS_DIR)/moondream2-text-model-f16_ct-q4_0.gguf
-	mmproj=$(VLM_MODELS_DIR)/moondream2-mmproj-f16.gguf
-	if [ ! -f $$model ]; then
-		echo "Downloading Moondream2 model ..."
-		curl -fL --retry 3 -o $$model $(VLM_MOONDREAM_MODEL_URL)
-	else
-		echo "Moondream2 model already present — skipping."
-	fi
-	if [ ! -f $$mmproj ]; then
-		echo "Downloading Moondream2 mmproj ..."
-		curl -fL --retry 3 -o $$mmproj $(VLM_MOONDREAM_MMPROJ_URL)
-	else
-		echo "Moondream2 mmproj already present — skipping."
-	fi
-	echo ""
-	echo "  Now install llama-cpp-python for your hardware (NOT auto-installed):"
-	if [ "$$(uname -s)" = "Darwin" ]; then
-		echo "    CMAKE_ARGS='-DLLAMA_METAL=on' uv pip install llama-cpp-python    # macOS Metal"
-	elif command -v nvidia-smi > /dev/null 2>&1; then
-		echo "    uv pip install llama-cpp-python --extra-index-url $(LLAMA_CPP_INDEX_CUDA124)    # CUDA 12.4 detected"
-	else
-		echo "    uv pip install llama-cpp-python --extra-index-url $(LLAMA_CPP_INDEX_CPU)    # CPU"
-	fi
-	echo ""
-	echo "  Then add this to .cc-senses.toml:"
-	echo ""
-	echo "    [vlm]"
-	echo "    model_path = \"$$model\""
-	echo "    mmproj_path = \"$$mmproj\""
-	echo "    handler_name = \"moondream\""
+	uv run python -m cc_vlm.setup_models moondream
 
-setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (alt VLM, richer output)
+setup_see_qwen25: ## Install /see deps + download Qwen2.5-VL-3B (in-process alt)
 	uv sync --extra see
-	mkdir -p $(VLM_MODELS_DIR)
-	model=$(VLM_MODELS_DIR)/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
-	mmproj=$(VLM_MODELS_DIR)/mmproj-Qwen2.5-VL-3B-Instruct-f16.gguf
-	if [ ! -f $$model ]; then
-		echo "Downloading Qwen2.5-VL-3B model ..."
-		curl -fL --retry 3 -o $$model $(VLM_QWEN25_MODEL_URL)
-	else
-		echo "Qwen2.5-VL-3B model already present — skipping."
-	fi
-	if [ ! -f $$mmproj ]; then
-		echo "Downloading Qwen2.5-VL-3B mmproj ..."
-		curl -fL --retry 3 -o $$mmproj $(VLM_QWEN25_MMPROJ_URL)
-	else
-		echo "Qwen2.5-VL-3B mmproj already present — skipping."
-	fi
-	echo ""
-	echo "  Then add this to .cc-senses.toml:"
-	echo ""
-	echo "    [vlm]"
-	echo "    model_path = \"$$model\""
-	echo "    mmproj_path = \"$$mmproj\""
-	echo "    handler_name = \"qwen2.5vl\""
+	uv run python -m cc_vlm.setup_models qwen25vl
+
+setup_see_qwen3vl: ## Install /see deps + download Qwen3-VL-2B (llamaserver, ~1.55 GB)
+	uv sync --extra see
+	uv run python -m cc_vlm.setup_models qwen3vl
+
+setup_see_smolvlm: ## Install /see deps + download SmolVLM-500M (llamaserver, 546 MB)
+	uv sync --extra see
+	uv run python -m cc_vlm.setup_models smolvlm
 
 setup_user: setup setup_kokoro ## End user minimum: package + best local TTS (no dev tools)
 	@echo ""
@@ -134,6 +86,11 @@ setup_all: setup_dev setup_espeak setup_piper setup_kokoro setup_stt ## Develope
 	@echo "✓ cc-senses-plugin ready."
 	@echo "  Try: cc-tts 'hello from claude code'"
 	@echo "  Then in Claude Code: /speak --toggle"
+
+setup_default_all: setup_dev setup_espeak setup_piper setup_kokoro setup_stt setup_see ## Kitchen-sink: dev + all TTS + STT + /see (Moondream2)
+	@echo ""
+	@echo "✓ cc-senses-plugin fully installed (default in-process VLM path)."
+	@echo "  /speak /listen /see all ready."
 
 clean: ## Remove venv + caches (preserves downloaded TTS/STT/VLM models)
 	rm -rf .venv .pytest_cache .ruff_cache .coverage

--- a/README.md
+++ b/README.md
@@ -31,13 +31,7 @@ Session summary generated with three engines for comparison:
 
 ```bash
 make setup_default_all   # kitchen-sink: dev + all TTS + STT + /see (Moondream2)
-# — or granular —
-make setup_dev           # install package + dev deps
-make setup_espeak        # install espeak-ng + mpv (zero-config baseline)
-make setup_piper         # install Piper (neural)
-make setup_kokoro        # install Kokoro (best local)
-make setup_see           # /see only: Moondream2 in-process (~3.75 GB)
-make setup_see_smolvlm   # /see only: SmolVLM-500M via llama-server (546 MB)
+make help                # all other setup, validation, plugin, and run recipes
 
 cc-tts-wrap claude       # live PTY-wrapped TTS
 cc-tts "Hello"           # one-shot CLI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Local multimodal I/O for Claude Code. TTS speaks Claude's responses aloud, STT c
 
 - **TTS** — `/speak` skill, Stop-hook auto-read, multi-engine (Kokoro / Piper / espeak-ng / edge-tts)
 - **STT** — `/listen` skill, Moonshine/Vosk auto-detect, mic capture with VAD, PTY injection
-- **VLM** — `/see` skill, in-process Moondream2 via llama-cpp-python (Qwen2.5-VL alt), screen → text into Claude's context (~120 tokens/call vs ~1,600 raw vision)
+- **VLM** — `/see` skill, four-tier model ladder (Moondream2 in-process default; Qwen2.5-VL-3B in-process alt; Qwen3-VL-2B / SmolVLM-500M via `llama-server` opt-in), screen → text into Claude's context (~120 tokens/call vs ~1,600 raw vision)
 
 ## Audio Examples
 
@@ -30,13 +30,17 @@ Session summary generated with three engines for comparison:
 ## Quick Start
 
 ```bash
-make setup_dev      # install package + dev deps
-make setup_espeak   # install espeak-ng + mpv (zero-config baseline)
-make setup_piper    # install Piper (neural)
-make setup_kokoro   # install Kokoro (best local)
+make setup_default_all   # kitchen-sink: dev + all TTS + STT + /see (Moondream2)
+# — or granular —
+make setup_dev           # install package + dev deps
+make setup_espeak        # install espeak-ng + mpv (zero-config baseline)
+make setup_piper         # install Piper (neural)
+make setup_kokoro        # install Kokoro (best local)
+make setup_see           # /see only: Moondream2 in-process (~3.75 GB)
+make setup_see_smolvlm   # /see only: SmolVLM-500M via llama-server (546 MB)
 
-cc-tts-wrap claude  # live PTY-wrapped TTS
-cc-tts "Hello"      # one-shot CLI
+cc-tts-wrap claude       # live PTY-wrapped TTS
+cc-tts "Hello"           # one-shot CLI
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Session summary generated with three engines for comparison:
 ## Quick Start
 
 ```bash
-make setup_default_all   # kitchen-sink: dev + all TTS + STT + /see (Moondream2)
-make help                # all other setup, validation, plugin, and run recipes
+make setup_default_all       # kitchen-sink install: dev + all TTS + STT + /see (Moondream2)
+make plugin_install_local    # register the plugin in Claude Code (project scope)
+make run_cc                  # start Claude Code with the plugin
+make help                    # other recipes (granular setup, validation, run modes)
 
-cc-tts-wrap claude       # live PTY-wrapped TTS
-cc-tts "Hello"           # one-shot CLI
+cc-tts-wrap claude           # test TTS without CC: live PTY-wrapped
+cc-tts "Hello"               # test TTS without CC: one-shot CLI
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Local multimodal I/O bridge for Claude Code — TTS output via `/speak`, STT input via `/listen`, screen-vision via `/see`.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.10.0-58f4c2.svg)
+![Version](https://img.shields.io/badge/version-0.10.1-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/codeql.yaml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin/badge)](https://www.codefactor.io/repository/github/qte77/cc-senses-plugin)
 [![Dependabot](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/qte77/cc-senses-plugin/actions/workflows/dependabot/dependabot-updates)

--- a/docs/adr/0003-vlm-screen-sharing.md
+++ b/docs/adr/0003-vlm-screen-sharing.md
@@ -57,3 +57,26 @@ the lifecycle additions.
 
 See [`docs/architecture.md` § VLM Pipeline](../architecture.md#vlm-pipeline)
 for the current state of all of this.
+
+## Update (2026-05-15) — TOML-driven model registry + llamaserver opt-in targets
+
+v0.10.1 reorganizes the install layer without changing the engine layer:
+
+- **`src/cc_vlm/models.toml`** becomes the single source of truth for VLM
+  model URLs, engine routing, and `[vlm]` snippet shape. The previous approach
+  (URL constants + hand-typed filenames in the Makefile) drifted apart in
+  practice and shipped two dead URLs by v0.10.0. Filenames are now derived
+  from URL basenames; drift is structurally impossible.
+- **`python -m cc_vlm.setup_models <key>`** replaces the per-target curl
+  loops. Make recipes shrink to one-liners. Platform-aware install hints
+  (macOS Metal / CUDA / CPU for llama-cpp-python; dnf/brew/source for
+  llama-server) move into the Python module.
+- **Two new opt-in `llamaserver` Make targets**: `setup_see_qwen3vl`
+  (Qwen3-VL-2B Q4_K_M, ~1.55 GB) and `setup_see_smolvlm` (SmolVLM-500M Q8,
+  546 MB). Default in-process tier stays on Moondream2; the Q8 mmproj on
+  the new tiers keeps the footprint small enough for low-spec laptops.
+- **`setup_default_all`** kitchen-sink target installs dev tools, all TTS
+  engines, STT, and the in-process default `/see` tier in one command.
+
+Engine default and config schema are unchanged. The `[vlm]` block emitted by
+`setup_models` matches what `cc_vlm.config.VLMConfig` already accepts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,17 +116,23 @@ Cold start: 3-5 s (model load). Warm page cache: 1-2 s. In-process reuse: 200-50
 
 ### Supported VLM models (llama-cpp-python handlers)
 
-| handler_name | llama_cpp class | Model family |
-|---|---|---|
-| `moondream` (default) | `MoondreamChatHandler` | Moondream2 (~0.9 GB Q4, fastest CPU path) |
-| `qwen2.5vl` | `Qwen25VLChatHandler` | Qwen2.5-VL-2B/3B/7B (richer output, ~1.6 GB Q4) |
-| `llava15` | `Llava15ChatHandler` | LLaVA 1.5 |
-| `llava16` | `Llava16ChatHandler` | LLaVA 1.6 |
-| `minicpmv` | `MiniCPMv26ChatHandler` | MiniCPM-V 2.6 |
-| `nanollava` | `NanollavaChatHandler` | NanoLLaVA |
+| handler_name | llama_cpp class | Model family | Total install |
+|---|---|---|---|
+| `moondream` (default) | `MoondreamChatHandler` | Moondream2 (F16, fastest CPU path) | ~3.75 GB |
+| `qwen2.5vl` | `Qwen25VLChatHandler` | Qwen2.5-VL-3B (Q4_K_M, richer output) | ~3.27 GB |
+| `llava15` | `Llava15ChatHandler` | LLaVA 1.5 | — |
+| `llava16` | `Llava16ChatHandler` | LLaVA 1.6 | — |
+| `minicpmv` | `MiniCPMv26ChatHandler` | MiniCPM-V 2.6 | — |
+| `nanollava` | `NanollavaChatHandler` | NanoLLaVA | — |
 
-Default chosen for smallest CPU footprint; install via `make setup_see`.
-For richer output swap to `qwen2.5vl` via `make setup_see_qwen25`.
+Install paths: `make setup_see` (Moondream2, recommended) or `make setup_see_qwen25`
+(Qwen2.5-VL alt). For newer models with no in-process handler yet — Qwen3-VL-2B
+and SmolVLM-500M — use the `llamaserver` opt-in targets `make setup_see_qwen3vl`
+and `make setup_see_smolvlm`.
+
+URLs, filenames, engine routing, and the `[vlm]` snippet template all live in
+`src/cc_vlm/models.toml`; Make recipes delegate to `python -m cc_vlm.setup_models <key>`
+to avoid the URL/filename drift class of bug that shipped before v0.10.1.
 
 ### VLM token budget
 

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -97,20 +97,22 @@ for full details.
 See [`docs/architecture.md` § VLM engine comparison](architecture.md#vlm-engine-comparison)
 and the supported-handlers table for full details.
 
-| handler | role | license |
-|---|---|---|
-| `moondream` (default) | Moondream2, ~0.9 GB Q4, fastest CPU path | Apache 2.0 |
-| `qwen2.5vl` | Qwen2.5-VL-2B/3B/7B, richer output, ~1.6 GB Q4 | Apache 2.0 |
-| `llava15` / `llava16` | LLaVA 1.5 / 1.6 | Apache 2.0 |
-| `minicpmv` | MiniCPM-V 2.6 | Apache 2.0 |
-| `nanollava` | NanoLLaVA | Apache 2.0 |
+| handler / target | role | total install | license |
+|---|---|---|---|
+| `moondream` (default in-process) | Moondream2 F16, fastest CPU path | ~3.75 GB | Apache 2.0 |
+| `qwen2.5vl` (in-process alt) | Qwen2.5-VL-3B Q4_K_M, richer output | ~3.27 GB | Apache 2.0 |
+| `qwen3vl` (llamaserver opt-in) | Qwen3-VL-2B Q4_K_M + Q8 mmproj | ~1.55 GB | Apache 2.0 |
+| `smolvlm` (llamaserver opt-in) | SmolVLM-500M Q8 + Q8 mmproj | 546 MB | Apache 2.0 |
+| `llava15` / `llava16` | LLaVA 1.5 / 1.6 (in-process, no `make` target) | — | Apache 2.0 |
+| `minicpmv` | MiniCPM-V 2.6 (in-process, no `make` target) | — | Apache 2.0 |
+| `nanollava` | NanoLLaVA (in-process, no `make` target) | — | Apache 2.0 |
 
 Shipped via two engine classes in `src/cc_vlm/engine.py`:
 
 - `LlamaCppVLMEngine` — in-process via llama-cpp-python (dispatched on `handler_name`).
-- `LlamaServerVLMEngine` — HTTP via llama-server (PR #107/#108; user-managed in Phase 1, lazy auto-spawn in Phase 2, SessionStart preload in Phase 3). Routes around the abetlen/llama-cpp-python handler gap and gives genuinely-warm-across-invocations latency, which the in-process backend cannot in the `/see` CLI workflow (each `/see` spawns a fresh Python process).
+- `LlamaServerVLMEngine` — HTTP via mainline llama-server (PR #107/#108; user-managed in Phase 1, lazy auto-spawn in Phase 2, SessionStart preload in Phase 3). Routes around the abetlen/llama-cpp-python handler gap and gives genuinely-warm-across-invocations latency, which the in-process backend cannot in the `/see` CLI workflow (each `/see` spawns a fresh Python process).
 
-**SmolVLM2-2.2B** and **Qwen3-VL-2B** are reachable today via the `llamaserver` engine — both are blocked on missing `*ChatHandler` classes in `abetlen/llama-cpp-python` (Qwen3-VL: upstream #2080; SmolVLM2: no handler upstream at all).
+The two `llamaserver` opt-in models (**Qwen3-VL-2B**, **SmolVLM-500M**) are shipped via `make setup_see_qwen3vl` and `make setup_see_smolvlm` as of v0.10.1. The in-process `qwen3vl` handler is still tracked at #102 (blocked on upstream `abetlen/llama-cpp-python` #2080); `LlamaServerVLMEngine` is the unblock path.
 
 ### Considered / deferred
 
@@ -118,7 +120,7 @@ To be filed as issues; placeholder list for now.
 
 | Candidate | Status | Notes |
 |---|---|---|
-| **`Qwen3VLChatHandler` for in-process backend** | deferred (tracker #102) | Blocked on [`abetlen/llama-cpp-python` #2080](https://github.com/abetlen/llama-cpp-python/issues/2080). Add `"qwen3vl"` to `_HANDLER_MAP` once the upstream class lands. Until then, `LlamaServerVLMEngine` is the unblock path. |
+| **`Qwen3VLChatHandler` for in-process backend** | deferred (tracker #102) | Blocked on [`abetlen/llama-cpp-python` #2080](https://github.com/abetlen/llama-cpp-python/issues/2080). Add `"qwen3vl"` to `_HANDLER_MAP` once the upstream class lands. Until then, `make setup_see_qwen3vl` configures the model on the `LlamaServerVLMEngine` path. |
 | **`available()` hardening for handler-class-mismatch** | deferred (tracker #103) | `engine.py:available()` only checks `handler_name in _HANDLER_MAP`, not whether the class actually exists in the installed `llama_cpp.llama_chat_format` module. Latent footgun for any new handler we add. |
 | **`ClaudeVisionEngine` fallback** | deferred (per ADR-0003 Tier 1) | Returns image path reference for Claude's built-in vision instead of running a local VLM. ~1,600 tokens/call (vs ~120 for local VLM). Opt-in `--vision` flag. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cc-senses-plugin"
-version = "0.10.0"
+version = "0.10.1"
 description = "Local multimodal I/O bridge for Claude Code — TTS (/speak), STT (/listen), VLM (/see)"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -96,7 +96,7 @@ exclude_lines = [
 
 
 [tool.bumpversion]
-current_version = "0.10.0"
+current_version = "0.10.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/skills/see/SKILL.md
+++ b/skills/see/SKILL.md
@@ -14,12 +14,19 @@ Capture the screen, run a local vision-language model (Moondream2 by default via
 ## Install
 
 ```bash
-make setup_see           # default: Moondream2 (~0.9 GB Q4, fastest CPU)
-# or
-make setup_see_qwen25    # alt: Qwen2.5-VL-3B (~1.6 GB Q4, richer output)
+make setup_see              # default in-process: Moondream2 F16 (~3.75 GB)
+make setup_see_qwen25       # in-process alt: Qwen2.5-VL-3B Q4_K_M (~3.27 GB)
+make setup_see_qwen3vl      # llamaserver opt-in: Qwen3-VL-2B Q4_K_M (~1.55 GB)
+make setup_see_smolvlm      # llamaserver opt-in: SmolVLM-500M Q8 (546 MB)
 ```
 
-Each target installs `--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-plugin/models/`, and prints both the matching `llama-cpp-python` install command (run it manually — hardware-specific) and the `[vlm]` snippet to drop into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml) for the full `[vlm]` schema.
+URLs, filenames, and `[vlm]` snippet shape all live in `src/cc_vlm/models.toml`; the
+Make recipes delegate to `python -m cc_vlm.setup_models <key>`. Each target installs
+`--extra see` deps, downloads the GGUF + mmproj into `~/.cache/cc-senses-plugin/models/`,
+prints the engine-specific runtime install hint (`llama-cpp-python` wheel for in-process;
+`llama-server` binary for the llamaserver tiers), and prints the `[vlm]` snippet to paste
+into `.cc-senses.toml`. See [`.cc-senses.example.toml`](../../.cc-senses.example.toml)
+for the full `[vlm]` schema.
 
 ## Engines
 
@@ -170,4 +177,8 @@ There is **no undo for past descriptions** that were injected into a Claude Code
 
 ## Status
 
-Development — functional MVP. Ships `LlamaCppVLMEngine` only. Follow-ups (`LlamaServerVLMEngine` HTTP backend, Claude Vision opt-in, focused-window crop, auto-template detection, persistent cache) are tracked in the roadmap. See [`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).
+Development — functional MVP. Ships both `LlamaCppVLMEngine` (in-process, default)
+and `LlamaServerVLMEngine` (mainline llama-server, opt-in via `setup_see_qwen3vl` /
+`setup_see_smolvlm`). Follow-ups (Claude Vision opt-in, focused-window crop,
+auto-template detection, persistent cache) are tracked in the roadmap. See
+[`docs/adr/0003-vlm-screen-sharing.md`](../../docs/adr/0003-vlm-screen-sharing.md).

--- a/src/cc_stt/__init__.py
+++ b/src/cc_stt/__init__.py
@@ -1,3 +1,3 @@
 """cc-stt: Speech-to-text module for cc-senses-plugin plugin."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/src/cc_tts/__init__.py
+++ b/src/cc_tts/__init__.py
@@ -1,3 +1,3 @@
 """cc-senses-plugin: Local multimodal I/O bridge for Claude Code (TTS module)."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/src/cc_vlm/models.toml
+++ b/src/cc_vlm/models.toml
@@ -1,0 +1,42 @@
+# VLM model registry — single source of truth for setup_see* Make targets.
+#
+# Each entry is a model key (used as the CLI argument to setup_models).
+# Required keys:
+#   title       — human-readable name for log lines
+#   engine      — "llamacpp" (in-process) or "llamaserver" (mainline binary)
+#   model_url   — GGUF text-model URL on HuggingFace
+#   mmproj_url  — GGUF mmproj URL on HuggingFace
+# Engine-specific keys:
+#   handler_name — required iff engine == "llamacpp" (maps to llama-cpp-python class)
+#   server_url   — required iff engine == "llamaserver" (loopback by default)
+#
+# Filenames are derived from URL basenames automatically — never set them here.
+# URL liveness is verified by tests/preflight_vlm_urls.sh before changes land.
+
+[moondream]
+title = "Moondream2"
+engine = "llamacpp"
+handler_name = "moondream"
+model_url = "https://huggingface.co/moondream/moondream2-gguf/resolve/main/moondream2-text-model-f16.gguf"
+mmproj_url = "https://huggingface.co/moondream/moondream2-gguf/resolve/main/moondream2-mmproj-f16.gguf"
+
+[qwen25vl]
+title = "Qwen2.5-VL-3B"
+engine = "llamacpp"
+handler_name = "qwen2.5vl"
+model_url = "https://huggingface.co/lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf"
+mmproj_url = "https://huggingface.co/lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-model-f16.gguf"
+
+[qwen3vl]
+title = "Qwen3-VL-2B"
+engine = "llamaserver"
+server_url = "http://127.0.0.1:8080"
+model_url = "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/Qwen3VL-2B-Instruct-Q4_K_M.gguf"
+mmproj_url = "https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf"
+
+[smolvlm]
+title = "SmolVLM-500M"
+engine = "llamaserver"
+server_url = "http://127.0.0.1:8080"
+model_url = "https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/SmolVLM-500M-Instruct-Q8_0.gguf"
+mmproj_url = "https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf"

--- a/src/cc_vlm/setup_models.py
+++ b/src/cc_vlm/setup_models.py
@@ -1,0 +1,153 @@
+"""TOML-driven VLM model registry: download GGUFs and emit a `[vlm]` snippet.
+
+Replaces the previous Makefile-string-template approach. URL/filename drift is
+structurally impossible because filenames are derived from URL basenames.
+
+Usage from a Make recipe:
+
+    uv run python -m cc_vlm.setup_models <key>
+
+Where <key> is a section header in `models.toml` (e.g. `moondream`, `qwen3vl`).
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import sys
+import tomllib
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MODELS_TOML = Path(__file__).parent / "models.toml"
+MODELS_DIR = Path.home() / ".cache" / "cc-senses-plugin" / "models"
+
+_VALID_ENGINES = ("llamacpp", "llamaserver")
+_LLAMA_CPP_INDEX_CPU = "https://abetlen.github.io/llama-cpp-python/whl/cpu"
+_LLAMA_CPP_INDEX_CUDA124 = "https://abetlen.github.io/llama-cpp-python/whl/cu124"
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    key: str
+    title: str
+    engine: str
+    model_url: str
+    mmproj_url: str
+    handler_name: str | None = None
+    server_url: str | None = None
+
+    @property
+    def model_filename(self) -> str:
+        return self.model_url.rsplit("/", 1)[-1]
+
+    @property
+    def mmproj_filename(self) -> str:
+        return self.mmproj_url.rsplit("/", 1)[-1]
+
+
+def load_models(path: Path | None = None) -> dict[str, ModelSpec]:
+    source = path if path is not None else MODELS_TOML
+    raw: dict[str, dict[str, Any]] = tomllib.loads(source.read_text(encoding="utf-8"))
+    return {key: _build_spec(key, body) for key, body in raw.items()}
+
+
+def _build_spec(key: str, body: dict[str, Any]) -> ModelSpec:
+    engine = body.get("engine", "")
+    if engine not in _VALID_ENGINES:
+        raise ValueError(f"{key}: engine must be one of {_VALID_ENGINES}, got {engine!r}")
+    if engine == "llamacpp" and "handler_name" not in body:
+        raise ValueError(f"{key}: engine='llamacpp' requires handler_name")
+    if engine == "llamaserver" and "server_url" not in body:
+        raise ValueError(f"{key}: engine='llamaserver' requires server_url")
+    return ModelSpec(
+        key=key,
+        title=body["title"],
+        engine=engine,
+        model_url=body["model_url"],
+        mmproj_url=body["mmproj_url"],
+        handler_name=body.get("handler_name"),
+        server_url=body.get("server_url"),
+    )
+
+
+def download(url: str, dest: Path) -> bool:
+    """Download `url` to `dest`. Returns True if downloaded, False if already present."""
+    if dest.exists():
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url) as resp, dest.open("wb") as out:  # noqa: S310
+        shutil.copyfileobj(resp, out)
+    return True
+
+
+def format_snippet(spec: ModelSpec, model_path: Path, mmproj_path: Path) -> str:
+    """Emit the `[vlm]` block the user pastes into `.cc-senses.toml`."""
+    lines = ["[vlm]"]
+    if spec.engine == "llamaserver":
+        lines.append('engine = "llamaserver"')
+        lines.append(f'server_url = "{spec.server_url}"')
+    else:
+        lines.append(f'handler_name = "{spec.handler_name}"')
+    lines.append(f'model_path = "{model_path}"')
+    lines.append(f'mmproj_path = "{mmproj_path}"')
+    return "\n".join(lines)
+
+
+def _print_install_hint(spec: ModelSpec) -> None:
+    """Print the engine-specific runtime install instructions (not auto-installed)."""
+    if spec.engine == "llamacpp":
+        print("\n  Install llama-cpp-python for your hardware (NOT auto-installed):")
+        if platform.system() == "Darwin":
+            print(
+                "    CMAKE_ARGS='-DLLAMA_METAL=on' uv pip install llama-cpp-python    # macOS Metal"
+            )
+        elif shutil.which("nvidia-smi"):
+            print(
+                f"    uv pip install llama-cpp-python --extra-index-url "
+                f"{_LLAMA_CPP_INDEX_CUDA124}    # CUDA 12.4 detected"
+            )
+        else:
+            print(
+                f"    uv pip install llama-cpp-python --extra-index-url "
+                f"{_LLAMA_CPP_INDEX_CPU}    # CPU"
+            )
+    else:
+        print("\n  Requires llama-server on PATH (not auto-installed):")
+        print("    Fedora/RHEL: sudo dnf install llama.cpp")
+        print("    macOS:       brew install llama.cpp")
+        print("    Other:       https://github.com/ggml-org/llama.cpp/releases")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("Usage: python -m cc_vlm.setup_models <model-key>", file=sys.stderr)
+        return 2
+    key = args[0]
+    models = load_models()
+    if key not in models:
+        print(f"Unknown model {key!r}. Available: {sorted(models)}", file=sys.stderr)
+        return 1
+    spec = models[key]
+    model_path = MODELS_DIR / spec.model_filename
+    mmproj_path = MODELS_DIR / spec.mmproj_filename
+    for label, url, dest in (
+        (f"{spec.title} model", spec.model_url, model_path),
+        (f"{spec.title} mmproj", spec.mmproj_url, mmproj_path),
+    ):
+        if download(url, dest):
+            print(f"Downloaded {label} -> {dest}")
+        else:
+            print(f"{label} already present - skipping.")
+    _print_install_hint(spec)
+    print("\n  Add this to .cc-senses.toml:\n")
+    for line in format_snippet(spec, model_path, mmproj_path).splitlines():
+        print(f"    {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/preflight_vlm_urls.sh
+++ b/tests/preflight_vlm_urls.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-flight: verify every VLM model GGUF URL referenced by the Makefile
+# returns HTTP 200. Run from an unsandboxed terminal — Claude Code's sandbox
+# blocks huggingface.co.
+#
+# Usage:
+#   bash tests/preflight_vlm_urls.sh
+#   bash tests/preflight_vlm_urls.sh | tee /tmp/vlm_url_check.log
+#
+# Exit code: 0 if all URLs are 200, 1 otherwise.
+
+set -uo pipefail
+
+urls=(
+  https://huggingface.co/moondream/moondream2-gguf/resolve/main/moondream2-text-model-f16.gguf
+  https://huggingface.co/moondream/moondream2-gguf/resolve/main/moondream2-mmproj-f16.gguf
+  https://huggingface.co/lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf
+  https://huggingface.co/lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-model-f16.gguf
+  https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/Qwen3VL-2B-Instruct-Q4_K_M.gguf
+  https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf
+  https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/SmolVLM-500M-Instruct-Q8_0.gguf
+  https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf
+)
+
+fail=0
+for url in "${urls[@]}"; do
+  code=$(curl -sIL -o /dev/null -w '%{http_code}' --max-time 30 "$url" || echo "ERR")
+  printf '%s  %s\n' "$code" "$url"
+  [[ "$code" == "200" ]] || fail=1
+done
+
+if [[ "$fail" -eq 0 ]]; then
+  printf '\nAll 8 URLs returned 200.\n'
+else
+  printf '\nOne or more URLs failed. Re-check before locking into the Makefile.\n' >&2
+fi
+
+exit "$fail"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,18 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from cc_tts.config import TTSConfig, load_config
-
-
-class TestTTSConfigDefaults:
-    def test_defaults(self) -> None:
-        config = TTSConfig()
-        assert config.engine == "auto"
-        assert config.voice == "en_US-amy-medium"
-        assert config.speed == 1.0
-        assert config.auto_read is False
-        assert config.max_chars == 2000
-        assert config.player == "auto"
+from cc_tts.config import load_config
 
 
 class TestLoadConfigFromToml:

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -2,10 +2,12 @@
 
 Verifies the targets exist and dry-run-print the expected commands.
 Run via `make -n <target>`; output is parsed for required substrings.
+URL constants are parsed directly from the Makefile to avoid a subprocess.
 """
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -13,6 +15,26 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+MAKEFILE = REPO_ROOT / "Makefile"
+
+HF_URL_RE = re.compile(r"^https://huggingface\.co/[^/]+/[^/]+/resolve/main/[^/]+\.gguf$")
+URL_VAR_RE = re.compile(r"^(VLM_\w+_URL)\s*:=\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _url_vars() -> dict[str, str]:
+    return {m.group(1): m.group(2) for m in URL_VAR_RE.finditer(_makefile_text())}
+
+
+def _phony_line() -> str:
+    """Return the full .PHONY declaration with continuations folded into one line."""
+    text = _makefile_text()
+    match = re.search(r"^\.PHONY:\s*((?:.*\\\n)*.*)$", text, re.MULTILINE)
+    assert match, ".PHONY declaration missing"
+    return match.group(1).replace("\\\n", " ")
 
 
 @pytest.fixture
@@ -61,3 +83,148 @@ class TestSetupSeeQwen25:
     def test_setup_see_qwen25_references_qwen25_model(self, make_available: None) -> None:
         result = _make_dry_run("setup_see_qwen25")
         assert "Qwen2.5-VL" in result.stdout
+
+
+class TestVLMUrlConstants:
+    """The four dead URL sources (ggml-org/moondream2-20250414-GGUF + bartowski 3B)
+    must be replaced with canonical / mirror repos, and four new URLs for the
+    llamaserver opt-in targets must exist."""
+
+    def test_moondream_uses_canonical_repo(self) -> None:
+        urls = _url_vars()
+        assert "moondream/moondream2-gguf" in urls["VLM_MOONDREAM_MODEL_URL"]
+        assert "moondream/moondream2-gguf" in urls["VLM_MOONDREAM_MMPROJ_URL"]
+        # Dead repo must be gone
+        assert "ggml-org/moondream2-20250414-GGUF" not in _makefile_text()
+
+    def test_qwen25_uses_lmstudio_mirror(self) -> None:
+        urls = _url_vars()
+        assert "lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF" in urls["VLM_QWEN25_MODEL_URL"]
+        assert "lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF" in urls["VLM_QWEN25_MMPROJ_URL"]
+        # Removed bartowski 3B repo must be gone
+        assert "bartowski/Qwen2.5-VL-3B-Instruct-GGUF" not in _makefile_text()
+
+    def test_qwen3vl_url_constants_present(self) -> None:
+        urls = _url_vars()
+        assert "VLM_QWEN3VL_MODEL_URL" in urls
+        assert "VLM_QWEN3VL_MMPROJ_URL" in urls
+        assert "Qwen/Qwen3-VL-2B-Instruct-GGUF" in urls["VLM_QWEN3VL_MODEL_URL"]
+        assert "Qwen/Qwen3-VL-2B-Instruct-GGUF" in urls["VLM_QWEN3VL_MMPROJ_URL"]
+
+    def test_smolvlm_url_constants_present(self) -> None:
+        urls = _url_vars()
+        assert "VLM_SMOLVLM_MODEL_URL" in urls
+        assert "VLM_SMOLVLM_MMPROJ_URL" in urls
+        assert "ggml-org/SmolVLM-500M-Instruct-GGUF" in urls["VLM_SMOLVLM_MODEL_URL"]
+        assert "ggml-org/SmolVLM-500M-Instruct-GGUF" in urls["VLM_SMOLVLM_MMPROJ_URL"]
+
+    def test_all_url_constants_have_valid_hf_shape(self) -> None:
+        urls = _url_vars()
+        # Must be at least 8 URL vars (4 in-process + 4 llamaserver) after the fix
+        assert len(urls) >= 8, f"expected >=8 VLM_*_URL constants, got {sorted(urls)}"
+        for name, url in urls.items():
+            assert HF_URL_RE.match(url), f"{name} has unexpected URL shape: {url!r}"
+
+
+class TestNewSetupTargets:
+    def test_setup_see_qwen3vl_target_exists(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see_qwen3vl")
+        assert result.returncode == 0, f"setup_see_qwen3vl target missing — stderr: {result.stderr}"
+
+    def test_setup_see_smolvlm_target_exists(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see_smolvlm")
+        assert result.returncode == 0, f"setup_see_smolvlm target missing — stderr: {result.stderr}"
+
+    def test_setup_default_all_target_exists(self, make_available: None) -> None:
+        result = _make_dry_run("setup_default_all")
+        assert result.returncode == 0, f"setup_default_all target missing — stderr: {result.stderr}"
+
+
+class TestLlamaserverSnippets:
+    """Opt-in llamaserver targets must print a [vlm] block with engine="llamaserver"
+    and the loopback server_url."""
+
+    @pytest.mark.parametrize("target", ["setup_see_qwen3vl", "setup_see_smolvlm"])
+    def test_prints_llamaserver_engine_and_server_url(
+        self, make_available: None, target: str
+    ) -> None:
+        result = _make_dry_run(target)
+        assert 'engine = "llamaserver"' in result.stdout
+        assert 'server_url = "http://127.0.0.1:8080"' in result.stdout
+
+
+class TestInProcessSnippetsRegression:
+    """In-process targets must NOT print the llamaserver engine key — guards
+    against copy-paste of the new snippet template into the old recipes."""
+
+    def test_setup_see_does_not_print_llamaserver_engine(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see")
+        assert 'engine = "llamaserver"' not in result.stdout
+
+    def test_setup_see_qwen25_does_not_print_llamaserver_engine(self, make_available: None) -> None:
+        result = _make_dry_run("setup_see_qwen25")
+        assert 'engine = "llamaserver"' not in result.stdout
+
+
+class TestSetupDefaultAll:
+    """The kitchen-sink target must transitively run the in-process default
+    (setup_see/Moondream2) — not the opt-in llamaserver paths."""
+
+    def test_default_all_pulls_in_moondream(self, make_available: None) -> None:
+        result = _make_dry_run("setup_default_all")
+        assert "moondream2-text-model" in result.stdout
+
+    def test_default_all_does_not_pull_in_qwen3vl(self, make_available: None) -> None:
+        result = _make_dry_run("setup_default_all")
+        assert "Qwen3VL-2B-Instruct" not in result.stdout
+
+    def test_default_all_does_not_pull_in_smolvlm(self, make_available: None) -> None:
+        result = _make_dry_run("setup_default_all")
+        assert "SmolVLM-500M-Instruct" not in result.stdout
+
+
+class TestPhony:
+    """The three new targets must be on the .PHONY line."""
+
+    @pytest.mark.parametrize(
+        "target", ["setup_see_qwen3vl", "setup_see_smolvlm", "setup_default_all"]
+    )
+    def test_phony_lists_new_target(self, target: str) -> None:
+        assert target in _phony_line()
+
+
+class TestFilenamesMatchUrlBasenames:
+    """Each setup_see* recipe writes the downloaded file to a path whose basename
+    must match the URL basename — guards against the prior bug class where the
+    Makefile asked curl for `f16.gguf` but saved as `f16_ct-q4_0.gguf`."""
+
+    @pytest.mark.parametrize(
+        ("target", "model_var", "mmproj_var"),
+        [
+            ("setup_see", "VLM_MOONDREAM_MODEL_URL", "VLM_MOONDREAM_MMPROJ_URL"),
+            ("setup_see_qwen25", "VLM_QWEN25_MODEL_URL", "VLM_QWEN25_MMPROJ_URL"),
+            ("setup_see_qwen3vl", "VLM_QWEN3VL_MODEL_URL", "VLM_QWEN3VL_MMPROJ_URL"),
+            ("setup_see_smolvlm", "VLM_SMOLVLM_MODEL_URL", "VLM_SMOLVLM_MMPROJ_URL"),
+        ],
+    )
+    def test_recipe_paths_match_url_basenames(
+        self,
+        make_available: None,
+        target: str,
+        model_var: str,
+        mmproj_var: str,
+    ) -> None:
+        urls = _url_vars()
+        assert model_var in urls and mmproj_var in urls, (
+            f"URL constants missing for {target}: need {model_var}, {mmproj_var}"
+        )
+        result = _make_dry_run(target)
+        assert result.returncode == 0, f"{target} dry-run failed: {result.stderr}"
+        model_basename = urls[model_var].rsplit("/", 1)[-1]
+        mmproj_basename = urls[mmproj_var].rsplit("/", 1)[-1]
+        assert model_basename in result.stdout, (
+            f"{target}: recipe does not save to URL basename {model_basename!r}"
+        )
+        assert mmproj_basename in result.stdout, (
+            f"{target}: recipe does not save to URL basename {mmproj_basename!r}"
+        )

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,230 +1,32 @@
-"""Smoke tests for Makefile setup_* targets.
+"""Integration check: every Makefile setup_see* target must invoke
+`python -m cc_vlm.setup_models` with a key that exists in models.toml.
 
-Verifies the targets exist and dry-run-print the expected commands.
-Run via `make -n <target>`; output is parsed for required substrings.
-URL constants are parsed directly from the Makefile to avoid a subprocess.
+This is the only Makefile-level test worth keeping after the pivot — it catches
+the failure mode where someone adds a Make target but forgets the TOML stanza,
+or renames a TOML key but leaves the Make recipe stale.
+
+All other Makefile assertions (target exists, dry-run succeeds, .PHONY shape)
+are either trivial smoke checks or are subsumed by the setup_models test suite.
 """
 
 from __future__ import annotations
 
 import re
-import shutil
-import subprocess
 from pathlib import Path
 
-import pytest
+from cc_vlm.setup_models import load_models
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAKEFILE = REPO_ROOT / "Makefile"
 
-HF_URL_RE = re.compile(r"^https://huggingface\.co/[^/]+/[^/]+/resolve/main/[^/]+\.gguf$")
-URL_VAR_RE = re.compile(r"^(VLM_\w+_URL)\s*:=\s*(\S+)\s*$", re.MULTILINE)
+SETUP_MODELS_INVOCATION_RE = re.compile(r"python\s+-m\s+cc_vlm\.setup_models\s+(\S+)")
 
 
-def _makefile_text() -> str:
-    return MAKEFILE.read_text(encoding="utf-8")
-
-
-def _url_vars() -> dict[str, str]:
-    return {m.group(1): m.group(2) for m in URL_VAR_RE.finditer(_makefile_text())}
-
-
-def _phony_line() -> str:
-    """Return the full .PHONY declaration with continuations folded into one line."""
-    text = _makefile_text()
-    match = re.search(r"^\.PHONY:\s*((?:.*\\\n)*.*)$", text, re.MULTILINE)
-    assert match, ".PHONY declaration missing"
-    return match.group(1).replace("\\\n", " ")
-
-
-@pytest.fixture
-def make_available() -> None:
-    if shutil.which("make") is None:
-        pytest.skip("make not available in this environment")
-
-
-def _make_dry_run(target: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["make", "-n", target],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
+def test_every_setup_models_invocation_uses_a_known_key() -> None:
+    keys_in_use = set(SETUP_MODELS_INVOCATION_RE.findall(MAKEFILE.read_text(encoding="utf-8")))
+    known_keys = set(load_models())
+    unknown = keys_in_use - known_keys
+    assert not unknown, (
+        f"Makefile invokes cc_vlm.setup_models with keys not present in models.toml: "
+        f"{sorted(unknown)}. Known keys: {sorted(known_keys)}"
     )
-
-
-class TestSetupSee:
-    def test_setup_see_target_exists(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see")
-        assert result.returncode == 0, f"setup_see target missing — stderr: {result.stderr}"
-
-    def test_setup_see_runs_uv_sync_with_see_extra(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see")
-        assert "uv sync --extra see" in result.stdout
-
-    def test_setup_see_references_moondream_model(self, make_available: None) -> None:
-        """Default downloads must point at Moondream2 GGUF + mmproj."""
-        result = _make_dry_run("setup_see")
-        out = result.stdout.lower()
-        assert "moondream" in out
-
-    def test_setup_see_does_not_reference_qwen25_as_default(self, make_available: None) -> None:
-        """The Qwen2.5-VL alt is in setup_see_qwen25, not the default target."""
-        result = _make_dry_run("setup_see")
-        # The dry-run output for setup_see should not pull in Qwen2.5-VL URLs.
-        assert "qwen2.5-vl" not in result.stdout.lower()
-
-
-class TestSetupSeeQwen25:
-    def test_setup_see_qwen25_target_exists(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see_qwen25")
-        assert result.returncode == 0, f"setup_see_qwen25 target missing — stderr: {result.stderr}"
-
-    def test_setup_see_qwen25_references_qwen25_model(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see_qwen25")
-        assert "Qwen2.5-VL" in result.stdout
-
-
-class TestVLMUrlConstants:
-    """The four dead URL sources (ggml-org/moondream2-20250414-GGUF + bartowski 3B)
-    must be replaced with canonical / mirror repos, and four new URLs for the
-    llamaserver opt-in targets must exist."""
-
-    def test_moondream_uses_canonical_repo(self) -> None:
-        urls = _url_vars()
-        assert "moondream/moondream2-gguf" in urls["VLM_MOONDREAM_MODEL_URL"]
-        assert "moondream/moondream2-gguf" in urls["VLM_MOONDREAM_MMPROJ_URL"]
-        # Dead repo must be gone
-        assert "ggml-org/moondream2-20250414-GGUF" not in _makefile_text()
-
-    def test_qwen25_uses_lmstudio_mirror(self) -> None:
-        urls = _url_vars()
-        assert "lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF" in urls["VLM_QWEN25_MODEL_URL"]
-        assert "lmstudio-community/Qwen2.5-VL-3B-Instruct-GGUF" in urls["VLM_QWEN25_MMPROJ_URL"]
-        # Removed bartowski 3B repo must be gone
-        assert "bartowski/Qwen2.5-VL-3B-Instruct-GGUF" not in _makefile_text()
-
-    def test_qwen3vl_url_constants_present(self) -> None:
-        urls = _url_vars()
-        assert "VLM_QWEN3VL_MODEL_URL" in urls
-        assert "VLM_QWEN3VL_MMPROJ_URL" in urls
-        assert "Qwen/Qwen3-VL-2B-Instruct-GGUF" in urls["VLM_QWEN3VL_MODEL_URL"]
-        assert "Qwen/Qwen3-VL-2B-Instruct-GGUF" in urls["VLM_QWEN3VL_MMPROJ_URL"]
-
-    def test_smolvlm_url_constants_present(self) -> None:
-        urls = _url_vars()
-        assert "VLM_SMOLVLM_MODEL_URL" in urls
-        assert "VLM_SMOLVLM_MMPROJ_URL" in urls
-        assert "ggml-org/SmolVLM-500M-Instruct-GGUF" in urls["VLM_SMOLVLM_MODEL_URL"]
-        assert "ggml-org/SmolVLM-500M-Instruct-GGUF" in urls["VLM_SMOLVLM_MMPROJ_URL"]
-
-    def test_all_url_constants_have_valid_hf_shape(self) -> None:
-        urls = _url_vars()
-        # Must be at least 8 URL vars (4 in-process + 4 llamaserver) after the fix
-        assert len(urls) >= 8, f"expected >=8 VLM_*_URL constants, got {sorted(urls)}"
-        for name, url in urls.items():
-            assert HF_URL_RE.match(url), f"{name} has unexpected URL shape: {url!r}"
-
-
-class TestNewSetupTargets:
-    def test_setup_see_qwen3vl_target_exists(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see_qwen3vl")
-        assert result.returncode == 0, f"setup_see_qwen3vl target missing — stderr: {result.stderr}"
-
-    def test_setup_see_smolvlm_target_exists(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see_smolvlm")
-        assert result.returncode == 0, f"setup_see_smolvlm target missing — stderr: {result.stderr}"
-
-    def test_setup_default_all_target_exists(self, make_available: None) -> None:
-        result = _make_dry_run("setup_default_all")
-        assert result.returncode == 0, f"setup_default_all target missing — stderr: {result.stderr}"
-
-
-class TestLlamaserverSnippets:
-    """Opt-in llamaserver targets must print a [vlm] block with engine="llamaserver"
-    and the loopback server_url."""
-
-    @pytest.mark.parametrize("target", ["setup_see_qwen3vl", "setup_see_smolvlm"])
-    def test_prints_llamaserver_engine_and_server_url(
-        self, make_available: None, target: str
-    ) -> None:
-        result = _make_dry_run(target)
-        assert 'engine = "llamaserver"' in result.stdout
-        assert 'server_url = "http://127.0.0.1:8080"' in result.stdout
-
-
-class TestInProcessSnippetsRegression:
-    """In-process targets must NOT print the llamaserver engine key — guards
-    against copy-paste of the new snippet template into the old recipes."""
-
-    def test_setup_see_does_not_print_llamaserver_engine(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see")
-        assert 'engine = "llamaserver"' not in result.stdout
-
-    def test_setup_see_qwen25_does_not_print_llamaserver_engine(self, make_available: None) -> None:
-        result = _make_dry_run("setup_see_qwen25")
-        assert 'engine = "llamaserver"' not in result.stdout
-
-
-class TestSetupDefaultAll:
-    """The kitchen-sink target must transitively run the in-process default
-    (setup_see/Moondream2) — not the opt-in llamaserver paths."""
-
-    def test_default_all_pulls_in_moondream(self, make_available: None) -> None:
-        result = _make_dry_run("setup_default_all")
-        assert "moondream2-text-model" in result.stdout
-
-    def test_default_all_does_not_pull_in_qwen3vl(self, make_available: None) -> None:
-        result = _make_dry_run("setup_default_all")
-        assert "Qwen3VL-2B-Instruct" not in result.stdout
-
-    def test_default_all_does_not_pull_in_smolvlm(self, make_available: None) -> None:
-        result = _make_dry_run("setup_default_all")
-        assert "SmolVLM-500M-Instruct" not in result.stdout
-
-
-class TestPhony:
-    """The three new targets must be on the .PHONY line."""
-
-    @pytest.mark.parametrize(
-        "target", ["setup_see_qwen3vl", "setup_see_smolvlm", "setup_default_all"]
-    )
-    def test_phony_lists_new_target(self, target: str) -> None:
-        assert target in _phony_line()
-
-
-class TestFilenamesMatchUrlBasenames:
-    """Each setup_see* recipe writes the downloaded file to a path whose basename
-    must match the URL basename — guards against the prior bug class where the
-    Makefile asked curl for `f16.gguf` but saved as `f16_ct-q4_0.gguf`."""
-
-    @pytest.mark.parametrize(
-        ("target", "model_var", "mmproj_var"),
-        [
-            ("setup_see", "VLM_MOONDREAM_MODEL_URL", "VLM_MOONDREAM_MMPROJ_URL"),
-            ("setup_see_qwen25", "VLM_QWEN25_MODEL_URL", "VLM_QWEN25_MMPROJ_URL"),
-            ("setup_see_qwen3vl", "VLM_QWEN3VL_MODEL_URL", "VLM_QWEN3VL_MMPROJ_URL"),
-            ("setup_see_smolvlm", "VLM_SMOLVLM_MODEL_URL", "VLM_SMOLVLM_MMPROJ_URL"),
-        ],
-    )
-    def test_recipe_paths_match_url_basenames(
-        self,
-        make_available: None,
-        target: str,
-        model_var: str,
-        mmproj_var: str,
-    ) -> None:
-        urls = _url_vars()
-        assert model_var in urls and mmproj_var in urls, (
-            f"URL constants missing for {target}: need {model_var}, {mmproj_var}"
-        )
-        result = _make_dry_run(target)
-        assert result.returncode == 0, f"{target} dry-run failed: {result.stderr}"
-        model_basename = urls[model_var].rsplit("/", 1)[-1]
-        mmproj_basename = urls[mmproj_var].rsplit("/", 1)[-1]
-        assert model_basename in result.stdout, (
-            f"{target}: recipe does not save to URL basename {model_basename!r}"
-        )
-        assert mmproj_basename in result.stdout, (
-            f"{target}: recipe does not save to URL basename {mmproj_basename!r}"
-        )

--- a/tests/test_setup_models.py
+++ b/tests/test_setup_models.py
@@ -1,0 +1,149 @@
+"""Tests for cc_vlm.setup_models — TOML-driven model registry + CLI.
+
+Each test targets a real bug class:
+- Filename/URL drift (the bug that shipped the dead Makefile URLs)
+- Engine/schema mismatch (llamacpp missing handler_name, etc.)
+- Snippet leakage across engines (in-process target accidentally emits server_url)
+- CLI error paths (unknown key, missing arg)
+
+Trivial existence/data-echo tests are deliberately omitted.
+"""
+
+from __future__ import annotations
+
+import io
+import tomllib
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+from cc_vlm.setup_models import (
+    MODELS_TOML,
+    ModelSpec,
+    format_snippet,
+    load_models,
+    main,
+)
+
+# --- Data-shape contract: filenames come from URLs, never hand-typed ---
+
+
+class TestFilenameDerivation:
+    """The original bug — Makefile hardcoded `f16_ct-q4_0.gguf` while the URL
+    pointed at a different filename. After pivot, filename comes from URL basename
+    by construction. This test makes the property hold for every shipped model."""
+
+    @pytest.mark.parametrize("key", ["moondream", "qwen25vl", "qwen3vl", "smolvlm"])
+    def test_filenames_match_url_basenames(self, key: str) -> None:
+        spec = load_models()[key]
+        assert spec.model_filename == spec.model_url.rsplit("/", 1)[-1]
+        assert spec.mmproj_filename == spec.mmproj_url.rsplit("/", 1)[-1]
+
+
+# --- Schema enforcement: engine-specific required keys ---
+
+
+class TestSchemaValidation:
+    def _write(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "models.toml"
+        path.write_text(body)
+        return path
+
+    def test_llamacpp_missing_handler_name_raises(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[m]\ntitle="x"\nengine="llamacpp"\n'
+            'model_url="https://h/a/b/resolve/main/m.gguf"\n'
+            'mmproj_url="https://h/a/b/resolve/main/p.gguf"\n',
+        )
+        with pytest.raises(ValueError, match="handler_name"):
+            load_models(path)
+
+    def test_llamaserver_missing_server_url_raises(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[m]\ntitle="x"\nengine="llamaserver"\n'
+            'model_url="https://h/a/b/resolve/main/m.gguf"\n'
+            'mmproj_url="https://h/a/b/resolve/main/p.gguf"\n',
+        )
+        with pytest.raises(ValueError, match="server_url"):
+            load_models(path)
+
+    def test_unknown_engine_raises(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            '[m]\ntitle="x"\nengine="vllm"\n'
+            'model_url="https://h/a/b/resolve/main/m.gguf"\n'
+            'mmproj_url="https://h/a/b/resolve/main/p.gguf"\n',
+        )
+        with pytest.raises(ValueError, match="engine"):
+            load_models(path)
+
+
+# --- Snippet emission: each engine's [vlm] block has the right keys, no leakage ---
+
+
+class TestSnippetEmission:
+    def test_llamacpp_snippet_has_handler_name_and_no_server_url(self) -> None:
+        spec = ModelSpec(
+            key="m",
+            title="M",
+            engine="llamacpp",
+            handler_name="moondream",
+            model_url="https://h/a/b/resolve/main/m.gguf",
+            mmproj_url="https://h/a/b/resolve/main/p.gguf",
+        )
+        out = format_snippet(spec, Path("/tmp/m.gguf"), Path("/tmp/p.gguf"))
+        assert 'handler_name = "moondream"' in out
+        assert "server_url" not in out
+        assert 'engine = "llamaserver"' not in out
+
+    def test_llamaserver_snippet_has_server_url_and_no_handler_name(self) -> None:
+        spec = ModelSpec(
+            key="m",
+            title="M",
+            engine="llamaserver",
+            server_url="http://127.0.0.1:8080",
+            model_url="https://h/a/b/resolve/main/m.gguf",
+            mmproj_url="https://h/a/b/resolve/main/p.gguf",
+        )
+        out = format_snippet(spec, Path("/tmp/m.gguf"), Path("/tmp/p.gguf"))
+        assert 'engine = "llamaserver"' in out
+        assert 'server_url = "http://127.0.0.1:8080"' in out
+        assert "handler_name" not in out
+
+    def test_snippet_is_round_trip_parseable_as_toml(self) -> None:
+        """The emitted snippet must be valid TOML the user can paste verbatim."""
+        spec = load_models()["qwen3vl"]
+        out = format_snippet(spec, Path("/tmp/m.gguf"), Path("/tmp/p.gguf"))
+        # The snippet starts with [vlm], so tomllib will parse it as a section.
+        parsed = tomllib.loads(out)
+        assert parsed["vlm"]["engine"] == "llamaserver"
+        assert parsed["vlm"]["server_url"] == "http://127.0.0.1:8080"
+
+
+# --- CLI error paths ---
+
+
+class TestMainCLI:
+    def test_unknown_key_exits_nonzero_and_lists_available(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = main(["does-not-exist"])
+        assert rc != 0
+        # User must be told what IS available
+        assert "moondream" in stderr.getvalue()
+
+    def test_wrong_argv_count_returns_nonzero(self) -> None:
+        with redirect_stderr(io.StringIO()), redirect_stdout(io.StringIO()):
+            assert main([]) != 0
+            assert main(["a", "b"]) != 0
+
+
+# --- The TOML file ships in the package ---
+
+
+def test_models_toml_is_packaged() -> None:
+    """Sanity: the data file must be importable from the installed package, not
+    just present in the source tree. Catches missing hatch build inclusion."""
+    assert MODELS_TOML.is_file(), f"models.toml not found at {MODELS_TOML}"

--- a/tests/test_stt_config.py
+++ b/tests/test_stt_config.py
@@ -8,17 +8,6 @@ from cc_stt.config import STTConfig, load_stt_config
 
 
 class TestSTTConfigDefaults:
-    def test_defaults(self) -> None:
-        config = STTConfig()
-        assert config.engine == "auto"
-        assert config.language == "en"
-        assert config.wake_word == "hey_claude"
-        assert config.mic_device == "default"
-        assert config.auto_listen is False
-        assert config.strip_fillers is True
-        assert config.intent_match is True
-        assert config.max_words == 200
-
     def test_default_is_not_mutable_across_instances(self) -> None:
         a = STTConfig()
         b = STTConfig()

--- a/tests/test_stt_pty_input.py
+++ b/tests/test_stt_pty_input.py
@@ -30,16 +30,6 @@ class TestInjectText:
             os.close(master_fd)
             os.close(slave_fd)
 
-    def test_injects_with_newline(self) -> None:
-        master_fd, slave_fd = pty.openpty()
-        try:
-            inject_text(master_fd, "test input", newline=True)
-            data = _read_available(master_fd)
-            assert b"test input" in data
-        finally:
-            os.close(master_fd)
-            os.close(slave_fd)
-
     def test_empty_text_is_noop(self) -> None:
         master_fd, slave_fd = pty.openpty()
         try:

--- a/tests/test_vlm_config.py
+++ b/tests/test_vlm_config.py
@@ -9,34 +9,6 @@ import pytest
 from cc_vlm.config import VLMConfig, load_vlm_config
 
 
-class TestVLMConfigDefaults:
-    def test_defaults(self) -> None:
-        config = VLMConfig()
-        assert config.engine == "auto"
-        assert config.model_path == ""
-        assert config.mmproj_path == ""
-        assert config.handler_name == "moondream"
-        assert config.n_ctx == 4096
-        assert config.n_gpu_layers == 0
-        assert config.max_tokens == 256
-        assert config.max_dimension == 768
-        assert config.jpeg_quality == 85
-        assert config.template == "generic"
-        assert config.cache_size == 32
-
-    def test_llama_server_field_defaults(self) -> None:
-        """Phase 1 introduces six llama-server fields; Phase 1 wires server_url
-        and server_model_alias; the remaining four land as inert fields ready
-        for Phase 2/3 lifecycle work."""
-        config = VLMConfig()
-        assert config.server_url == ""
-        assert config.server_model_alias == ""
-        assert config.server_port == 8080
-        assert config.server_binary == "llama-server"
-        assert config.auto_spawn is True
-        assert config.preload is False
-
-
 class TestEnvOverrides:
     @pytest.fixture(autouse=True)
     def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_vlm_templates.py
+++ b/tests/test_vlm_templates.py
@@ -20,16 +20,8 @@ class TestPromptTemplates:
                 f"Template {name!r} missing word cap instruction"
             )
 
-    def test_templates_are_non_empty(self) -> None:
-        for name, prompt in PROMPT_TEMPLATES.items():
-            assert prompt.strip(), f"Template {name!r} is empty"
-
 
 class TestGetTemplate:
-    def test_returns_template_for_known_name(self) -> None:
-        assert get_template("terminal") == PROMPT_TEMPLATES["terminal"]
-        assert get_template("generic") == PROMPT_TEMPLATES["generic"]
-
     def test_raises_value_error_for_unknown(self) -> None:
         with pytest.raises(ValueError, match="Unknown template"):
             get_template("nonexistent")


### PR DESCRIPTION
## Summary

Stacked on #116. Removes 7 tests across 5 files whose assertions either echo data that the framework / source already guarantees, or duplicate another test in the same class.

## What was cut

| File | Test | Why |
|---|---|---|
| `test_config.py` | `TestTTSConfigDefaults.test_defaults` (whole class) | Re-asserts 6 pydantic defaults the framework enforces; covered transitively by every other config-loading test. |
| `test_stt_config.py` | `TestSTTConfigDefaults.test_defaults` | Same — 8 pydantic defaults. Class kept (other test in it is value-adding: `test_default_is_not_mutable_across_instances`). |
| `test_vlm_config.py` | `TestVLMConfigDefaults` (whole class) | Same — 14 pydantic defaults across 2 methods. |
| `test_stt_pty_input.py` | `TestInjectText.test_injects_with_newline` | DRY duplicate of `test_injects_text_to_pty` — same PTY setup, same `assert b"..." in data` shape, only the string literal differs. |
| `test_vlm_templates.py` | `TestPromptTemplates.test_templates_are_non_empty` | Asserts hardcoded string constants in source are non-empty. |
| `test_vlm_templates.py` | `TestGetTemplate.test_returns_template_for_known_name` | Tautology — `get_template` is a one-line `return PROMPT_TEMPLATES[name]` (templates.py:54). |

## What I deliberately KEPT (borderline)

- **Engine `.name` tests** (5: TTS espeak/piper/kokoro + STT moonshine/vosk) — `name` is the dispatch wire format consumed by `resolve_*_engine()`. Renaming silently breaks user configs. Cheap; real.
- **VLM engine constructor defaults** — not pydantic; the `__init__` defaults ARE the contract. A silent default change is the failure mode the test catches.
- **`TestNoMicrophoneError`** (subclass + message) — low value, cheap, user-visible string.

## Tests

- **411 → 404** tests; everything still green.
- ruff format/check, pyright (strict on src), all clean.

## Test plan

- [x] `make test` — 404 passed
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pyright src` — 0/0/0

⚠️ **Merge order**: this targets `chore/make-vlm-urls-and-llamaserver-targets` (PR #116). Merge #116 first, then GitHub will auto-retarget this PR to `main`.

Generated with Claude <noreply@anthropic.com>