### PR TITLE
ci(issues): add AI issue-triage via qte77/gha-issue-triage@v0.2.4

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,37 @@
+---
+# AI-powered issue triage via qte77/gha-issue-triage. Fires on every new,
+# edited, or reopened issue. Detects duplicates, scores relevance against
+# the repo's scope (README/AGENTS), analyzes feasibility + complexity,
+# auto-labels, and posts a single sticky summary comment that is edited
+# in place on re-runs.
+#
+# Backend defaults to GitHub Models via the workflow's GITHUB_TOKEN —
+# `permissions: models: read` is the load-bearing line. No external API
+# key required.
+#
+# Security note: the only ${{ ... }} interpolation here is
+# `github.event.issue.number` (numeric — safe in a concurrency-group
+# string). No untrusted issue body / title / comment text is used in a
+# run: command.
+name: issue-triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: qte77/gha-issue-triage@cc8f0cf99014af906ea3ad1ee977d92852069579  # v0.2.4
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/issue-triage.yaml` — composite action [`qte77/gha-issue-triage@v0.2.4`](https://github.com/qte77/gha-issue-triage) (SHA-pinned to `cc8f0cf99014af906ea3ad1ee977d92852069579`) that runs on `issues: [opened, edited, reopened]`.

Per fire it:
- Fuzzy-matches against existing **open** issues for duplicate detection
- Scores relevance (0-10) vs. repo scope read from `README.md` + `CLAUDE.md` / `AGENTS.md`
- Judges feasibility (yes/no) + complexity (low/medium/high)
- Applies labels additively: `duplicate`, `bug`, `feature`, `enhancement`, `good-first-issue`, `needs-discussion`, `invalid`
- Posts a single sticky summary comment, edited in place on re-runs

Backend: defaults to GitHub Models via `GITHUB_TOKEN` (`permissions: models: read` is load-bearing). No external API key needed.

## Notes / gotchas

- **Label collision (heads-up, not fixed in this PR):** repo currently has the GitHub default `good first issue` (with spaces). The bot will auto-create `good-first-issue` (hyphenated) on first low-complexity issue. Both labels will coexist — delete one manually if undesired.
- **Missing labels auto-created:** `feature`, `needs-discussion` (and `good-first-issue` per above) don't exist yet; bot creates them on first use.
- **Duplicate detection: open issues only.** Won't catch "already done by merged PR #N".
- **Concurrency:** per-issue group with `cancel-in-progress: true` — a burst of edits collapses to one run.
- **No untrusted interpolation:** the only `${{ ... }}` in the workflow is `github.event.issue.number` (numeric, safe in a concurrency-group string).

## Test plan

Post-merge, fire by editing an existing open issue with an invisible marker:

- [ ] `gh issue edit <N> --body-file <body-with-marker>` to trigger `edited`
- [ ] `gh run list --workflow=issue-triage.yaml --limit 3` → conclusion `success`, <10s
- [ ] Last comment authored by `github-actions[bot]`, contains `### AI triage summary`
- [ ] New labels applied additively; pre-existing labels preserved