### PR TITLE
chore(lockfile): sync self-version 0.10.0 → 0.10.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "cc-senses-plugin"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-settings" },


### PR DESCRIPTION
## Summary

`pyproject.toml` declares version `0.10.1` (bumped on the chore branch that landed via #116/#117) but the squash-merged `uv.lock` still pinned `cc-senses-plugin` at `0.10.0`. `uv lock` regenerates the lockfile and syncs only the self-version — no dependency churn.

## Test plan

- [x] `uv lock` resolved 62 packages with no other changes
- [x] Diff is +1/-1 on the project's own `[[package]]` entry